### PR TITLE
Week only page (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,40 +17,41 @@ For help getting started with Flutter, view our online
 [documentation](https://flutter.io/).
 
 ## Props
-| props | types | defaultValues |
-| :------------ |:---------------: |:---------------:|
-| weekDays | | ['Sun', 'Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat'] |
-| viewPortFraction | `double` | 1.0 |
-| prevDaysTextStyle | `TextStyle` | |
-| daysTextStyle | `TextStyle` | |
-| nextDaysTextStyle | `TextStyle` | |
-| prevMonthDayBorderColor | `Color` | Colors.transparent |
-| thisMonthDayBorderColor | `Color` | Colors.transparent |
-| nextMonthDayBorderColor | `Color` | Colors.transparent |
-| dayPadding | `double` | 2.0 |
-| height | `double` | double.infinity |
-| width | `double` | double.infinity |
-| todayTextStyle | `TextStyle` | `fontSize: 14.0, color: Colors.white` |
-| dayButtonColor | `Color` | Colors.red |
-| todayBorderColor | `Color` | Colors.red |
-| todayButtonColor | `Colors` | Colors.red |
-| selectedDateTime | `DateTime` | |
-| selectedDayTextStyle | `TextStyle` | `fontSize: 14.0, color: Colors.white` |
-| selectedDayBorderColor | `Color` | Colors.green |
-| selectedDayButtonColor | `Color` | Colors.green |
-| daysHaveCircularBorder | `bool` | |
-| onDayPressed | `Func` | |
-| weekdayTextStyle | `TextStyle` | `fontSize: 14.0, color: Colors.deepOrange` |
-| iconColor | `Color` | Colors.blueAccent |
-| headerTextStyle | `TextStyle` | `fontSize: 20.0, color: Colors.blue` |
-| headerText | `Text` | `Text('${DateFormat.yMMM().format(this._dates[1])}'`) |
-| weekendTextStyle | `TextStyle` | `fontSize: 14.0, color: Colors.pinkAccent` |
-| markedDates | `List<DateTime` | [] |
-| markedDateColor | `Color` | Colors.blueAccent |
-| markedDateWidget | `Color` | ``` Positioned(child: Container(color: Colors.blueAccent, height: 4.0, width: 4.0), bottom: 4.0, left: 18.0); ``` |
-| headerMargin | `EdgetInsets` | `const EdgeInsets.symmetric(vertical: 16.0)` |
-| childAspectRatio | `double` | `1.0` |
-| weekDayMargin | `EdgeInsets` | `const EdgeInsets.only(bottom: 4.0)` |
+| props                   | types           | defaultValues                                                                                                     |
+| :---------------------- | :-------------: | :---------------------------------------------------------------------------------------------------------------: |
+| weekDays                |                 | ['Sun', 'Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat']                                                                |
+| viewPortFraction        | `double`        | 1.0                                                                                                               |
+| prevDaysTextStyle       | `TextStyle`     |                                                                                                                   |
+| daysTextStyle           | `TextStyle`     |                                                                                                                   |
+| nextDaysTextStyle       | `TextStyle`     |                                                                                                                   |
+| prevMonthDayBorderColor | `Color`         | Colors.transparent                                                                                                |
+| thisMonthDayBorderColor | `Color`         | Colors.transparent                                                                                                |
+| nextMonthDayBorderColor | `Color`         | Colors.transparent                                                                                                |
+| dayPadding              | `double`        | 2.0                                                                                                               |
+| height                  | `double`        | double.infinity                                                                                                   |
+| width                   | `double`        | double.infinity                                                                                                   |
+| todayTextStyle          | `TextStyle`     | `fontSize: 14.0, color: Colors.white`                                                                             |
+| dayButtonColor          | `Color`         | Colors.red                                                                                                        |
+| todayBorderColor        | `Color`         | Colors.red                                                                                                        |
+| todayButtonColor        | `Colors`        | Colors.red                                                                                                        |
+| selectedDateTime        | `DateTime`      |                                                                                                                   |
+| selectedDayTextStyle    | `TextStyle`     | `fontSize: 14.0, color: Colors.white`                                                                             |
+| selectedDayBorderColor  | `Color`         | Colors.green                                                                                                      |
+| selectedDayButtonColor  | `Color`         | Colors.green                                                                                                      |
+| daysHaveCircularBorder  | `bool`          |                                                                                                                   |
+| onDayPressed            | `Func`          |                                                                                                                   |
+| weekdayTextStyle        | `TextStyle`     | `fontSize: 14.0, color: Colors.deepOrange`                                                                        |
+| iconColor               | `Color`         | Colors.blueAccent                                                                                                 |
+| headerTextStyle         | `TextStyle`     | `fontSize: 20.0, color: Colors.blue`                                                                              |
+| headerText              | `Text`          | `Text('${DateFormat.yMMM().format(this._dates[1])}'`)                                                             |
+| weekendTextStyle        | `TextStyle`     | `fontSize: 14.0, color: Colors.pinkAccent`                                                                        |
+| markedDates             | `List<DateTime` | []                                                                                                                |
+| markedDateColor         | `Color`         | Colors.blueAccent                                                                                                 |
+| markedDateWidget        | `Color`         | ``` Positioned(child: Container(color: Colors.blueAccent, height: 4.0, width: 4.0), bottom: 4.0, left: 18.0); ``` |
+| headerMargin            | `EdgetInsets`   | `const EdgeInsets.symmetric(vertical: 16.0)`                                                                      |
+| childAspectRatio        | `double`        | `1.0`                                                                                                             |
+| weekDayMargin           | `EdgeInsets`    | `const EdgeInsets.only(bottom: 4.0)`                                                                              |
+| weekFormat              | `bool`          | `false`                                                                                                           |
 
 ## Install
 Add ```flutter_calendar_carousel``` as a dependency in pubspec.yaml
@@ -89,8 +90,8 @@ Widget widget() {
 - [x] Set weekdays visibility.
 - [x] Customizable textStyles for days in weekend.
 - [x] Marked Dates.
-- [ ] Multiple days selections. 
-- [ ] Widget test. 
+- [ ] Multiple days selections.
+- [ ] Widget test.
 
 ## Help Maintenance
 I've been maintaining quite many repos these days and burning out slowly. If you could help me cheer up, buying me a cup of coffee will make my life really happy and get much energy out of it.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -71,6 +71,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.2"
+  date_utils:
+    dependency: transitive
+    description:
+      name: date_utils
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0+2"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -4,6 +4,7 @@ library flutter_calendar_dooboo;
 import 'package:intl/intl.dart' show DateFormat;
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:flutter/material.dart';
+import 'package:date_utils/date_utils.dart';
 
 class CalendarCarousel extends StatefulWidget {
   final TextStyle defaultHeaderTextStyle = TextStyle(
@@ -80,41 +81,42 @@ class CalendarCarousel extends StatefulWidget {
   final EdgeInsets headerMargin;
   final double childAspectRatio;
   final EdgeInsets weekDayMargin;
+  final bool weekFormat;
 
-  CalendarCarousel({
-    this.weekDays = const ['Sun', 'Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat'],
-    this.viewportFraction = 1.0,
-    this.prevDaysTextStyle,
-    this.daysTextStyle,
-    this.nextDaysTextStyle,
-    this.prevMonthDayBorderColor = Colors.transparent,
-    this.thisMonthDayBorderColor = Colors.transparent,
-    this.nextMonthDayBorderColor = Colors.transparent,
-    this.dayPadding = 2.0,
-    this.height = double.infinity,
-    this.width = double.infinity,
-    this.todayTextStyle,
-    this.dayButtonColor = Colors.transparent,
-    this.todayBorderColor = Colors.red,
-    this.todayButtonColor = Colors.red,
-    this.selectedDateTime,
-    this.selectedDayTextStyle,
-    this.selectedDayBorderColor = Colors.green,
-    this.selectedDayButtonColor = Colors.green,
-    this.daysHaveCircularBorder,
-    this.onDayPressed,
-    this.weekdayTextStyle,
-    this.iconColor = Colors.blueAccent,
-    this.headerTextStyle,
-    this.headerText,
-    this.weekendTextStyle,
-    this.markedDates,
-    @deprecated this.markedDateColor,
-    this.markedDateWidget,
-    this.headerMargin = const EdgeInsets.symmetric(vertical: 16.0),
-    this.childAspectRatio = 1.0,
-    this.weekDayMargin = const EdgeInsets.only(bottom: 4.0),
-  });
+  CalendarCarousel(
+      {this.weekDays = const ['Sun', 'Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat'],
+      this.viewportFraction = 1.0,
+      this.prevDaysTextStyle,
+      this.daysTextStyle,
+      this.nextDaysTextStyle,
+      this.prevMonthDayBorderColor = Colors.transparent,
+      this.thisMonthDayBorderColor = Colors.transparent,
+      this.nextMonthDayBorderColor = Colors.transparent,
+      this.dayPadding = 2.0,
+      this.height = double.infinity,
+      this.width = double.infinity,
+      this.todayTextStyle,
+      this.dayButtonColor = Colors.transparent,
+      this.todayBorderColor = Colors.red,
+      this.todayButtonColor = Colors.red,
+      this.selectedDateTime,
+      this.selectedDayTextStyle,
+      this.selectedDayBorderColor = Colors.green,
+      this.selectedDayButtonColor = Colors.green,
+      this.daysHaveCircularBorder,
+      this.onDayPressed,
+      this.weekdayTextStyle,
+      this.iconColor = Colors.blueAccent,
+      this.headerTextStyle,
+      this.headerText,
+      this.weekendTextStyle,
+      this.markedDates,
+      @deprecated this.markedDateColor,
+      this.markedDateWidget,
+      this.headerMargin = const EdgeInsets.symmetric(vertical: 16.0),
+      this.childAspectRatio = 1.0,
+      this.weekDayMargin = const EdgeInsets.only(bottom: 4.0),
+      this.weekFormat = false});
 
   @override
   _CalendarState createState() => _CalendarState();
@@ -123,6 +125,7 @@ class CalendarCarousel extends StatefulWidget {
 class _CalendarState extends State<CalendarCarousel> {
   PageController _controller;
   List<DateTime> _dates = List(3);
+  DateTime _selectedDate = DateTime.now();
   int _startWeekday = 0;
   int _endWeekday = 0;
 
@@ -161,32 +164,56 @@ class _CalendarState extends State<CalendarCarousel> {
               style: widget.headerTextStyle != null
                   ? widget.headerTextStyle
                   : widget.defaultHeaderTextStyle,
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: <Widget>[
-                  IconButton(
-                    onPressed: () => _setDate(page: 0),
-                    icon: Icon(
-                      Icons.keyboard_arrow_left,
-                      color: widget.iconColor,
-                    ),
-                  ),
-                  Container(
-                    child: widget.headerText != null
-                        ? widget.headerText
-                        : Text(
-                            '${DateFormat.yMMM().format(this._dates[1])}',
+              child: widget.weekFormat
+                  ? Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: <Widget>[
+                        IconButton(
+                          onPressed: () => resetToToday(),
+                          icon: Icon(Icons.today, color: widget.iconColor),
+                        ),
+                        Container(
+                          child: widget.headerText != null
+                              ? widget.headerText
+                              : Text(
+                                  '${DateFormat.yMMM().format(this._dates[1])}',
+                                ),
+                        ),
+                        IconButton(
+                          onPressed: () => selectDateFromPicker(),
+                          icon: Icon(
+                            Icons.calendar_today,
+                            color: widget.iconColor,
                           ),
-                  ),
-                  IconButton(
-                    onPressed: () => _setDate(page: 2),
-                    icon: Icon(
-                      Icons.keyboard_arrow_right,
-                      color: widget.iconColor,
+                        ),
+                      ],
+                    )
+                  : Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: <Widget>[
+                        IconButton(
+                          onPressed: () => _setDate(page: 0),
+                          icon: Icon(
+                            Icons.keyboard_arrow_left,
+                            color: widget.iconColor,
+                          ),
+                        ),
+                        Container(
+                          child: widget.headerText != null
+                              ? widget.headerText
+                              : Text(
+                                  '${DateFormat.yMMM().format(this._dates[1])}',
+                                ),
+                        ),
+                        IconButton(
+                          onPressed: () => _setDate(page: 2),
+                          icon: Icon(
+                            Icons.keyboard_arrow_right,
+                            color: widget.iconColor,
+                          ),
+                        ),
+                      ],
                     ),
-                  ),
-                ],
-              ),
             ),
           ),
           Container(
@@ -198,17 +225,19 @@ class _CalendarState extends State<CalendarCarousel> {
                   ),
           ),
           Expanded(
-            child: PageView.builder(
-              itemCount: 3,
-              onPageChanged: (value) {
-                this._setDate(page: value);
-              },
-              controller: _controller,
-              itemBuilder: (context, index) {
-                return builder(index);
-              },
-              pageSnapping: true,
-            ),
+            child: widget.weekFormat
+                ? Builder(builder: weekBuilder, key: widget.key)
+                : PageView.builder(
+                    itemCount: 3,
+                    onPageChanged: (value) {
+                      this._setDate(page: value);
+                    },
+                    controller: _controller,
+                    itemBuilder: (context, index) {
+                      return builder(index);
+                    },
+                    pageSnapping: true,
+                  ),
           ),
         ],
       ),
@@ -377,6 +406,170 @@ class _CalendarState extends State<CalendarCarousel> {
     );
   }
 
+  Widget weekBuilder(BuildContext context) {
+    List<DateTime> weekDays = getDaysInWeek(selectedDate: this._selectedDate);
+
+    return Stack(
+      children: <Widget>[
+        Positioned(
+          child: Container(
+            width: double.infinity,
+            height: double.infinity,
+            child: GridView.count(
+              crossAxisCount: 7,
+              childAspectRatio: widget.childAspectRatio,
+              padding: EdgeInsets.zero,
+              children: List.generate(weekDays.length,
+
+                  /// last day of month + weekday
+                  (index) {
+                bool isToday = weekDays[index].day == DateTime.now().day &&
+                    weekDays[index].month == DateTime.now().month &&
+                    weekDays[index].year == DateTime.now().year;
+                bool isSelectedDay = this._selectedDate != null &&
+                    this._selectedDate.year == weekDays[index].year &&
+                    this._selectedDate.month == weekDays[index].month &&
+                    this._selectedDate.day == weekDays[index].day;
+                bool isPrevMonthDay =
+                    weekDays[index].month < this._selectedDate.month;
+                bool isNextMonthDay =
+                    weekDays[index].month > this._selectedDate.month;
+                bool isThisMonthDay = !isPrevMonthDay && !isNextMonthDay;
+
+                DateTime now = weekDays[index];
+                TextStyle textStyle;
+                TextStyle defaultTextStyle;
+                if (isPrevMonthDay) {
+                  textStyle = widget.prevDaysTextStyle;
+                  defaultTextStyle = widget.defaultPrevDaysTextStyle;
+                } else if (isThisMonthDay) {
+                  textStyle = isSelectedDay
+                      ? widget.selectedDayTextStyle
+                      : isToday ? widget.todayTextStyle : widget.daysTextStyle;
+                  defaultTextStyle = isSelectedDay
+                      ? widget.defaultSelectedDayTextStyle
+                      : isToday
+                          ? widget.defaultTodayTextStyle
+                          : widget.defaultDaysTextStyle;
+                } else {
+                  textStyle = widget.nextDaysTextStyle;
+                  defaultTextStyle = widget.defaultNextDaysTextStyle;
+                }
+
+                return Container(
+                  margin: EdgeInsets.all(widget.dayPadding),
+                  child: FlatButton(
+                    color: isSelectedDay && widget.todayBorderColor != null
+                        ? widget.selectedDayBorderColor
+                        : isToday && widget.todayBorderColor != null
+                            ? widget.todayButtonColor
+                            : widget.dayButtonColor,
+                    onPressed: () => _onDayPressed(now),
+                    padding: EdgeInsets.all(widget.dayPadding),
+                    shape: widget.daysHaveCircularBorder == null
+                        ? CircleBorder()
+                        : widget.daysHaveCircularBorder
+                            ? CircleBorder(
+                                side: BorderSide(
+                                  color: isPrevMonthDay
+                                      ? widget.prevMonthDayBorderColor
+                                      : isNextMonthDay
+                                          ? widget.nextMonthDayBorderColor
+                                          : isToday &&
+                                                  widget.todayBorderColor !=
+                                                      null
+                                              ? widget.todayBorderColor
+                                              : widget.thisMonthDayBorderColor,
+                                ),
+                              )
+                            : RoundedRectangleBorder(
+                                side: BorderSide(
+                                  color: isPrevMonthDay
+                                      ? widget.prevMonthDayBorderColor
+                                      : isNextMonthDay
+                                          ? widget.nextMonthDayBorderColor
+                                          : isToday &&
+                                                  widget.todayBorderColor !=
+                                                      null
+                                              ? widget.todayBorderColor
+                                              : widget.thisMonthDayBorderColor,
+                                ),
+                              ),
+                    child: Stack(
+                      children: <Widget>[
+                        Center(
+                          child: DefaultTextStyle(
+                            style: (index % 7 == 0 || index % 7 == 6) &&
+                                    !isSelectedDay &&
+                                    !isToday
+                                ? widget.defaultWeekendTextStyle
+                                : isToday
+                                    ? widget.defaultTodayTextStyle
+                                    : defaultTextStyle,
+                            child: Text(
+                              '${now.day}',
+                              style: (index % 7 == 0 || index % 7 == 6) &&
+                                      !isSelectedDay &&
+                                      !isToday
+                                  ? widget.weekendTextStyle
+                                  : isToday ? widget.todayTextStyle : textStyle,
+                              maxLines: 1,
+                            ),
+                          ),
+                        ),
+                        _renderMarked(now),
+                      ],
+                    ),
+                  ),
+                );
+              }),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  List<DateTime> getDaysInWeek({DateTime selectedDate}) {
+    if (selectedDate == null) selectedDate = new DateTime.now();
+
+    var firstDayOfCurrentWeek = Utils.firstDayOfWeek(selectedDate);
+    var lastDayOfCurrentWeek = Utils.lastDayOfWeek(selectedDate);
+
+    return Utils.daysInRange(firstDayOfCurrentWeek, lastDayOfCurrentWeek)
+        .toList();
+  }
+
+  void resetToToday() {
+    _selectedDate = new DateTime.now();
+    setState(() {
+      this._selectedDate = _selectedDate;
+    });
+  }
+
+  void _onDayPressed(DateTime picked) {
+    if (picked == null) return;
+    setState(() {
+      this._selectedDate = picked;
+    });
+  }
+
+  Future<Null> selectDateFromPicker() async {
+    DateTime selected = await showDatePicker(
+      context: context,
+      initialDate: this._selectedDate ?? new DateTime.now(),
+      firstDate: new DateTime(1960),
+      lastDate: new DateTime(2050),
+    );
+
+    if (selected != null) {
+      setState(() {
+        this._selectedDate = selected;
+      });
+      // updating selected date range based on selected week
+    }
+  }
+
   void _setDate({
     int page,
   }) {
@@ -397,6 +590,8 @@ class _CalendarState extends State<CalendarCarousel> {
           date1,
           date2,
         ];
+        this._selectedDate =
+            widget.selectedDateTime ? widget.selectedDateTime : DateTime.now();
       });
     } else if (page == 1) {
       return;

--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -552,6 +552,7 @@ class _CalendarState extends State<CalendarCarousel> {
     setState(() {
       this._selectedDate = picked;
     });
+    widget.onDayPressed(picked);
   }
 
   Future<Null> selectDateFromPicker() async {
@@ -590,8 +591,9 @@ class _CalendarState extends State<CalendarCarousel> {
           date1,
           date2,
         ];
-        this._selectedDate =
-            widget.selectedDateTime ? widget.selectedDateTime : DateTime.now();
+        this._selectedDate = widget.selectedDateTime != null
+            ? widget.selectedDateTime
+            : DateTime.now();
       });
     } else if (page == 1) {
       return;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -64,6 +64,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.14.6"
+  date_utils:
+    dependency: "direct main"
+    description:
+      name: date_utils
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0+2"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   intl: ^0.15.7
   flutter:
     sdk: flutter
+  date_utils: ^0.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Added one optional parameter: **`weekFormat`**
It accepts a boolean argument and decides whether to use the week-only format or the regular calendar. Defaults to `FALSE`.

Layout is copied over from [apptreesoftware/flutter_calendar](https://github.com/apptreesoftware/flutter_calendar), but without the expandable full-size calendar. The right-side button lets the user selected a date to display its week. The left-side button jumps to the current date (today).

Otherwise the styling options, callback handling etc have not been changed.