### PR TITLE
WIP DateMarks customization

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -46,9 +46,9 @@ class MyHomePage extends StatefulWidget {
 class _MyHomePageState extends State<MyHomePage> {
   DateTime _currentDate = DateTime(2018, 8, 1);
   List<DateTime> _markedDate = [DateTime(2018, 9, 20), DateTime(2018, 10, 11)];
-  Map<DateTime, int> _markedDateMap = {
-    DateTime(2018, 9, 20) : 4,
-    DateTime(2018, 10, 11) : 1,
+  Map<DateTime, List<Widget>> _markedDateMap = {
+    DateTime(2018, 9, 20) : [DateMark.square()],
+    DateTime(2018, 10, 11) : [DateMark.dot(color: Colors.red), DateMark.dot(color: Colors.green), DateMark.square(color: Colors.blue)],
   };
 
   @override
@@ -73,7 +73,7 @@ class _MyHomePageState extends State<MyHomePage> {
 //          ),
 //          markedDates: _markedDate,
           weekFormat: false,
-          markedDatesMap: _markedDateMap,
+          listMarkedDates: _markedDateMap,
           height: 420.0,
           selectedDateTime: _currentDate,
           daysHaveCircularBorder: false, /// null for not rendering any border, true for circular border, false for rectangular border

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_calendar_carousel/flutter_calendar_carousel.dart' show CalendarCarousel;
+import 'package:flutter_calendar_carousel/flutter_calendar_carousel.dart' show CalendarCarousel, DateMark;
 
 void main() => runApp(new MyApp());
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -50,6 +50,10 @@ class _MyHomePageState extends State<MyHomePage> {
     DateTime(2018, 9, 20) : [DateMark.square()],
     DateTime(2018, 10, 11) : [DateMark.dot(color: Colors.red), DateMark.dot(color: Colors.green), DateMark.square(color: Colors.blue)],
   };
+  Map<DateTime, List<Widget>> _periods = {
+    DateTime(2018, 9, 20) : [DateMark.line(false, true)],
+    DateTime(2018, 9, 21) : [DateMark.line(true, false), DateMark.line(false, false, color: Colors.green)],
+  };
 
   @override
   Widget build(BuildContext context) {
@@ -74,6 +78,8 @@ class _MyHomePageState extends State<MyHomePage> {
 //          markedDates: _markedDate,
           weekFormat: false,
           listMarkedDates: _markedDateMap,
+//          periods: _periods,
+//          childAspectRatio: 0.7,
           height: 420.0,
           selectedDateTime: _currentDate,
           daysHaveCircularBorder: false, /// null for not rendering any border, true for circular border, false for rectangular border

--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -11,7 +11,7 @@ abstract class DateMark {
   static line(bool starting, bool ending, { Color color = Colors.blueAccent, double height = 4.00 }) => DatePeriodLine(starting: starting, ending: ending,color: color, height: height);
 }
 
-class DateMarkSquare {
+class DateMarkSquare extends StatelessWidget {
   final Color color;
   final double size;
   final EdgeInsetsGeometry margin;
@@ -33,7 +33,7 @@ class DateMarkSquare {
   }
 }
 
-class DateMarkDot {
+class DateMarkDot extends StatelessWidget {
   final Color color;
   final double size;
   final EdgeInsetsGeometry margin;
@@ -57,7 +57,7 @@ class DateMarkDot {
   }
 }
 
-class DatePeriodLine {
+class DatePeriodLine extends StatelessWidget {
   final Color color;
   final double height;
   /// The line start from the beginning of the day

--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -164,10 +164,11 @@ class CalendarCarousel extends StatefulWidget {
   final Widget headerText;
   final TextStyle weekendTextStyle;
   final List<DateTime> markedDates;
-  /// This is a list of widget for each date
+  /// This is a list of widget for each marked date
   final Map<DateTime, List<Widget>> listMarkedDates;
+  /// This is a list of widget for each period
+  final Map<DateTime, List<Widget>> periods;
   /// Provides a direction for the marking (horizontal or vertical)
-  final Axis markedDatesDirection;
   final Color markedDateColor;
   final Widget markedDateWidget;
   final EdgeInsets headerMargin;
@@ -210,7 +211,7 @@ class CalendarCarousel extends StatefulWidget {
     this.weekendTextStyle,
     @deprecated this.markedDates,
     this.listMarkedDates,
-    this.markedDatesDirection = Axis.horizontal,
+    this.periods = const {},
     @deprecated this.markedDateColor,
     this.markedDateWidget,
     this.headerMargin = const EdgeInsets.symmetric(vertical: 16.0),
@@ -415,82 +416,97 @@ class _CalendarState extends State<CalendarCarousel> {
                     margin: EdgeInsets.all(widget.dayPadding),
                     child: Column(
                       children: [
-                        FlatButton(
-                        color: isSelectedDay && widget.todayBorderColor != null
-                            ? widget.selectedDayBorderColor
-                            : isToday && widget.todayBorderColor != null
-                                ? widget.todayButtonColor
-                                : widget.dayButtonColor,
-                        onPressed: () => widget.onDayPressed(
-                            DateTime(year, month, index + 1 - _startWeekday)),
-                        padding: EdgeInsets.all(widget.dayPadding),
-                        shape: widget.daysHaveCircularBorder == null
-                            ? CircleBorder()
-                            : widget.daysHaveCircularBorder
-                                ? CircleBorder(
-                                    side: BorderSide(
-                                      color: isPrevMonthDay
-                                          ? widget.prevMonthDayBorderColor
-                                          : isNextMonthDay
-                                              ? widget.nextMonthDayBorderColor
-                                              : isToday &&
-                                                      widget.todayBorderColor !=
-                                                          null
-                                                  ? widget.todayBorderColor
-                                                  : widget
-                                                      .thisMonthDayBorderColor,
+                        Stack(
+                          children: [
+                          FlatButton(
+                          color: isSelectedDay && widget.todayBorderColor != null
+                              ? widget.selectedDayBorderColor
+                              : isToday && widget.todayBorderColor != null
+                                  ? widget.todayButtonColor
+                                  : widget.dayButtonColor,
+                          onPressed: () => widget.onDayPressed(
+                              DateTime(year, month, index + 1 - _startWeekday)),
+                          padding: EdgeInsets.all(widget.dayPadding),
+                          shape: widget.daysHaveCircularBorder == null
+                              ? CircleBorder()
+                              : widget.daysHaveCircularBorder
+                                  ? CircleBorder(
+                                      side: BorderSide(
+                                        color: isPrevMonthDay
+                                            ? widget.prevMonthDayBorderColor
+                                            : isNextMonthDay
+                                                ? widget.nextMonthDayBorderColor
+                                                : isToday &&
+                                                        widget.todayBorderColor !=
+                                                            null
+                                                    ? widget.todayBorderColor
+                                                    : widget
+                                                        .thisMonthDayBorderColor,
+                                      ),
+                                    )
+                                  : RoundedRectangleBorder(
+                                      side: BorderSide(
+                                        color: isPrevMonthDay
+                                            ? widget.prevMonthDayBorderColor
+                                            : isNextMonthDay
+                                                ? widget.nextMonthDayBorderColor
+                                                : isToday &&
+                                                        widget.todayBorderColor !=
+                                                            null
+                                                    ? widget.todayBorderColor
+                                                    : widget
+                                                        .thisMonthDayBorderColor,
+                                      ),
                                     ),
-                                  )
-                                : RoundedRectangleBorder(
-                                    side: BorderSide(
-                                      color: isPrevMonthDay
-                                          ? widget.prevMonthDayBorderColor
-                                          : isNextMonthDay
-                                              ? widget.nextMonthDayBorderColor
-                                              : isToday &&
-                                                      widget.todayBorderColor !=
-                                                          null
-                                                  ? widget.todayBorderColor
-                                                  : widget
-                                                      .thisMonthDayBorderColor,
-                                    ),
-                                  ),
-                        child: Stack(
-                          children: <Widget>[
-                            Center(
-                              child: DefaultTextStyle(
+                          child: Center(
+                            child: DefaultTextStyle(
+                              style: (_localeDate.dateSymbols.WEEKENDRANGE.contains((index - 1 + firstDayOfWeek) % 7)) &&
+                                      !isSelectedDay &&
+                                      !isToday
+                                  ? widget.defaultWeekendTextStyle
+                                  : isToday
+                                      ? widget.defaultTodayTextStyle
+                                      : defaultTextStyle,
+                              child: Text(
+                                '${now.day}',
                                 style: (_localeDate.dateSymbols.WEEKENDRANGE.contains((index - 1 + firstDayOfWeek) % 7)) &&
                                         !isSelectedDay &&
                                         !isToday
-                                    ? widget.defaultWeekendTextStyle
+                                    ? widget.weekendTextStyle
                                     : isToday
-                                        ? widget.defaultTodayTextStyle
-                                        : defaultTextStyle,
-                                child: Text(
-                                  '${now.day}',
-                                  style: (_localeDate.dateSymbols.WEEKENDRANGE.contains((index - 1 + firstDayOfWeek) % 7)) &&
-                                          !isSelectedDay &&
-                                          !isToday
-                                      ? widget.weekendTextStyle
-                                      : isToday
-                                          ? widget.todayTextStyle
-                                          : textStyle,
-                                  maxLines: 1,
-                                ),
+                                        ? widget.todayTextStyle
+                                        : textStyle,
+                                maxLines: 1,
                               ),
                             ),
-                          ],
+                          ),
                         ),
-                      ),
-                      widget.markedDates == null
-                          ? Flex(
-                                  direction: widget.markedDatesDirection,
-                                  crossAxisAlignment: CrossAxisAlignment.end,
-                                  mainAxisSize: MainAxisSize.max,
-                                  mainAxisAlignment: MainAxisAlignment.center,
-                                  children: _renderMarkedMap(now),
-                                )
+                        widget.markedDates == null
+                              ?  Positioned(	
+                                  bottom: 0.00,
+                                  left: 0.00,
+                                  right: 0.00,
+                                  child: Container(
+                                    padding: EdgeInsets.only(
+                                      bottom: 10.00
+                                    ),
+                                    child: Row(
+                                      crossAxisAlignment: CrossAxisAlignment.end,
+                                      mainAxisSize: MainAxisSize.max,
+                                      mainAxisAlignment: MainAxisAlignment.center,
+                                      children: _renderMarkedMap(now),
+                                    )
+                                  )
+                              )
                           : _renderMarked(now),
+                          ]
+                        ),
+                      Column(
+                        crossAxisAlignment: CrossAxisAlignment.end,
+                        mainAxisSize: MainAxisSize.max,
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: _renderPeriodsMap(now),
+                      ),
                     ])
                   );
                 }),
@@ -839,6 +855,23 @@ class _CalendarState extends State<CalendarCarousel> {
             key.month == now.month &&
             key.day == now.day) {
               return widget.listMarkedDates[key];
+        }
+      }
+    }
+    return [];
+  }
+  List<Widget> _renderPeriodsMap(DateTime now) {
+    if (widget.periods != null && widget.periods.length > 0) {
+      // Fastest way but works only if no timezones are provided and the hour is 00:00:00
+      if (widget.periods.containsKey(now)) {
+        return widget.periods[now];
+      }
+      // if nothing found we can check by value
+      for (DateTime key in widget.periods.keys) {
+        if (key.year == now.year &&
+            key.month == now.month &&
+            key.day == now.day) {
+              return widget.periods[key];
         }
       }
     }


### PR DESCRIPTION
As discussed in #20, it can be useful to have different colors or shape with the date marks.
This PR works around the code already done and modify the `markedDatesMap` variable into a `Map<DateTime, List<Widget>>` and adds a `periods` variable of the same attribute to display lines across multiple days. 
This PR also provides some helper function to construct some basic shapes: `DateMark.dot` and `DateMark.square`. Both functions returning a simple widget.
Since I had the use for lines across multiple days, I added (beside dots and squares) a line helper `DateMark.line`.
There is a usage example for square and dot, I'll add here one for lines across multiple days:
```dart
Class Home extends StatelessWidget {
  Map<DateTime, List<Widget>> _periods = {
    DateTime(2018, 9, 19) : [DateMark.line(false, true)],
    DateTime(2018, 9, 20) : [DateMark.line(true, true)],
    DateTime(2018, 9, 21) : [DateMark.line(true, false), DateMark.line(false, false)],
  };
  const Home();
  @override
  Widget build(BuildContext context) {
    return CalendarCarousel(periods: _periods, childAspectRatio: 0.6, dayPadding: 0,);
  }
}
```