### PR TITLE
[WIP] Refactoring - Move out default styles

### DIFF
--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -5,10 +5,9 @@ import 'dart:async';
 import 'package:date_utils/date_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_calendar_carousel/classes/event_list.dart';
+import 'package:flutter_calendar_carousel/src/default_styles.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:intl/intl.dart' show DateFormat;
-
-import 'src/src.dart';
 
 typedef MarkedDateIconBuilder<T> = Widget Function(T event);
 

--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -11,52 +11,6 @@ import 'package:intl/intl.dart' show DateFormat;
 typedef MarkedDateIconBuilder<T> = Widget Function(T event);
 
 class CalendarCarousel<T> extends StatefulWidget {
-  final TextStyle defaultHeaderTextStyle = TextStyle(
-    fontSize: 20.0,
-    color: Colors.blue,
-  );
-  final TextStyle defaultPrevDaysTextStyle = TextStyle(
-    color: Colors.grey,
-    fontSize: 14.0,
-  );
-  final TextStyle defaultNextDaysTextStyle = TextStyle(
-    color: Colors.grey,
-    fontSize: 14.0,
-  );
-  final TextStyle defaultDaysTextStyle = TextStyle(
-    color: Colors.black,
-    fontSize: 14.0,
-  );
-  final TextStyle defaultTodayTextStyle = TextStyle(
-    color: Colors.white,
-    fontSize: 14.0,
-  );
-  final TextStyle defaultSelectedDayTextStyle = TextStyle(
-    color: Colors.white,
-    fontSize: 14.0,
-  );
-  final TextStyle defaultWeekdayTextStyle = TextStyle(
-    color: Colors.deepOrange,
-    fontSize: 14.0,
-  );
-  final TextStyle defaultWeekendTextStyle = TextStyle(
-    color: Colors.pinkAccent,
-    fontSize: 14.0,
-  );
-  final TextStyle defaultInactiveDaysTextStyle = TextStyle(
-    color: Colors.black38,
-    fontSize: 14.0,
-  );
-  final TextStyle defaultInactiveWeekendTextStyle = TextStyle(
-    color: Colors.pinkAccent.withOpacity(0.6),
-    fontSize: 14.0,
-  );
-  final Widget defaultMarkedDateWidget = Container(
-    margin: EdgeInsets.symmetric(horizontal: 1.0),
-    color: Colors.blueAccent,
-    height: 4.0,
-    width: 4.0,
-  );
 
   final double viewportFraction;
   final TextStyle prevDaysTextStyle;

--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -8,6 +8,8 @@ import 'package:flutter_calendar_carousel/classes/event_list.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:intl/intl.dart' show DateFormat;
 
+import 'src/src.dart';
+
 typedef MarkedDateIconBuilder<T> = Widget Function(T event);
 
 class CalendarCarousel<T> extends StatefulWidget {
@@ -215,7 +217,7 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
                   child: DefaultTextStyle(
                       style: widget.headerTextStyle != null
                           ? widget.headerTextStyle
-                          : widget.defaultHeaderTextStyle,
+                          : defaultHeaderTextStyle,
                       child: Row(
                           mainAxisAlignment: MainAxisAlignment.spaceBetween,
                           children: <Widget>[
@@ -335,7 +337,7 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
                   if (isPrevMonthDay) {
                     now = now.subtract(Duration(days: _startWeekday - index));
                     textStyle = widget.prevDaysTextStyle;
-                    defaultTextStyle = widget.defaultPrevDaysTextStyle;
+                    defaultTextStyle = defaultPrevDaysTextStyle;
                   } else if (isThisMonthDay) {
                     now = DateTime(year, month, index + 1 - _startWeekday);
                     textStyle = isSelectedDay
@@ -344,14 +346,14 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
                             ? widget.todayTextStyle
                             : widget.daysTextStyle;
                     defaultTextStyle = isSelectedDay
-                        ? widget.defaultSelectedDayTextStyle
+                        ? defaultSelectedDayTextStyle
                         : isToday
-                            ? widget.defaultTodayTextStyle
-                            : widget.defaultDaysTextStyle;
+                            ? defaultTodayTextStyle
+                            : defaultDaysTextStyle;
                   } else {
                     now = DateTime(year, month, index + 1 - _startWeekday);
                     textStyle = widget.nextDaysTextStyle;
-                    defaultTextStyle = widget.defaultNextDaysTextStyle;
+                    defaultTextStyle = defaultNextDaysTextStyle;
                   }
                   bool isSelectable = true;
                   if (widget.minSelectedDate != null &&
@@ -417,18 +419,17 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
                                       !isSelectedDay &&
                                       !isToday
                                   ? (isPrevMonthDay
-                                      ? widget.defaultPrevDaysTextStyle
+                                      ? defaultPrevDaysTextStyle
                                       : isNextMonthDay
-                                          ? widget.defaultNextDaysTextStyle
+                                          ? defaultNextDaysTextStyle
                                           : isSelectable
-                                              ? widget.defaultWeekendTextStyle
-                                              : widget
-                                                  .defaultInactiveWeekendTextStyle)
+                                              ? defaultWeekendTextStyle
+                                              : defaultInactiveWeekendTextStyle)
                                   : isToday
-                                      ? widget.defaultTodayTextStyle
+                                      ? defaultTodayTextStyle
                                       : isSelectable
                                           ? defaultTextStyle
-                                          : widget.defaultInactiveDaysTextStyle,
+                                          : defaultInactiveDaysTextStyle,
                               child: Text(
                                 '${now.day}',
                                 style: (_localeDate.dateSymbols.WEEKENDRANGE
@@ -526,7 +527,7 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
                     TextStyle defaultTextStyle;
                     if (isPrevMonthDay) {
                       textStyle = widget.prevDaysTextStyle;
-                      defaultTextStyle = widget.defaultPrevDaysTextStyle;
+                      defaultTextStyle = defaultPrevDaysTextStyle;
                     } else if (isThisMonthDay) {
                       textStyle = isSelectedDay
                           ? widget.selectedDayTextStyle
@@ -534,13 +535,13 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
                               ? widget.todayTextStyle
                               : widget.daysTextStyle;
                       defaultTextStyle = isSelectedDay
-                          ? widget.defaultSelectedDayTextStyle
+                          ? defaultSelectedDayTextStyle
                           : isToday
-                              ? widget.defaultTodayTextStyle
-                              : widget.defaultDaysTextStyle;
+                              ? defaultTodayTextStyle
+                              : defaultDaysTextStyle;
                     } else {
                       textStyle = widget.nextDaysTextStyle;
-                      defaultTextStyle = widget.defaultNextDaysTextStyle;
+                      defaultTextStyle = defaultNextDaysTextStyle;
                     }
                     bool isSelectable = true;
                     if (widget.minSelectedDate != null &&
@@ -611,11 +612,10 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
                                         !isPrevMonthDay &&
                                         !isNextMonthDay
                                     ? (isSelectable
-                                        ? widget.defaultWeekendTextStyle
-                                        : widget
-                                            .defaultInactiveWeekendTextStyle)
+                                        ? defaultWeekendTextStyle
+                                        : defaultInactiveWeekendTextStyle)
                                     : isToday
-                                        ? widget.defaultTodayTextStyle
+                                        ? defaultTodayTextStyle
                                         : defaultTextStyle,
                                 child: Text(
                                   '${now.day}',
@@ -858,7 +858,7 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
           margin: widget.weekDayMargin,
           child: Center(
             child: DefaultTextStyle(
-              style: widget.defaultWeekdayTextStyle,
+              style: defaultWeekdayTextStyle,
               child: Text(
                 weekDay,
                 style: widget.weekdayTextStyle,
@@ -879,7 +879,7 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
       if (markedDates.contains(now)) {
         return widget.markedDateWidget != null
             ? widget.markedDateWidget
-            : widget.defaultMarkedDateWidget;
+            : defaultMarkedDateWidget;
       }
     }
     return Container();
@@ -968,7 +968,7 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
           if (widget.markedDateWidget != null) {
             tmp.add(widget.markedDateWidget);
           } else {
-            tmp.add(widget.defaultMarkedDateWidget);
+            tmp.add(defaultMarkedDateWidget);
           }
         }
       });

--- a/lib/src/default_styles.dart
+++ b/lib/src/default_styles.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+final TextStyle defaultHeaderTextStyle = TextStyle(
+	fontSize: 20.0,
+	color: Colors.blue,
+);
+final TextStyle defaultPrevDaysTextStyle = TextStyle(
+	color: Colors.grey,
+	fontSize: 14.0,
+);
+final TextStyle defaultNextDaysTextStyle = TextStyle(
+	color: Colors.grey,
+	fontSize: 14.0,
+);
+final TextStyle defaultDaysTextStyle = TextStyle(
+	color: Colors.black,
+	fontSize: 14.0,
+);
+final TextStyle defaultTodayTextStyle = TextStyle(
+	color: Colors.white,
+	fontSize: 14.0,
+);
+final TextStyle defaultSelectedDayTextStyle = TextStyle(
+	color: Colors.white,
+	fontSize: 14.0,
+);
+final TextStyle defaultWeekdayTextStyle = TextStyle(
+	color: Colors.deepOrange,
+	fontSize: 14.0,
+);
+final TextStyle defaultWeekendTextStyle = TextStyle(
+	color: Colors.pinkAccent,
+	fontSize: 14.0,
+);
+final TextStyle defaultInactiveDaysTextStyle = TextStyle(
+	color: Colors.black38,
+	fontSize: 14.0,
+);
+final TextStyle defaultInactiveWeekendTextStyle = TextStyle(
+	color: Colors.pinkAccent.withOpacity(0.6),
+	fontSize: 14.0,
+);
+final Widget defaultMarkedDateWidget = Container(
+	margin: EdgeInsets.symmetric(horizontal: 1.0),
+	color: Colors.blueAccent,
+	height: 4.0,
+	width: 4.0,
+);

--- a/lib/src/default_styles.dart
+++ b/lib/src/default_styles.dart
@@ -1,38 +1,38 @@
 import 'package:flutter/material.dart';
 
-final TextStyle defaultHeaderTextStyle = TextStyle(
+const TextStyle defaultHeaderTextStyle = const TextStyle(
 	fontSize: 20.0,
 	color: Colors.blue,
 );
-final TextStyle defaultPrevDaysTextStyle = TextStyle(
+const TextStyle defaultPrevDaysTextStyle = const TextStyle(
 	color: Colors.grey,
 	fontSize: 14.0,
 );
-final TextStyle defaultNextDaysTextStyle = TextStyle(
+const TextStyle defaultNextDaysTextStyle = const TextStyle(
 	color: Colors.grey,
 	fontSize: 14.0,
 );
-final TextStyle defaultDaysTextStyle = TextStyle(
+const TextStyle defaultDaysTextStyle = const TextStyle(
 	color: Colors.black,
 	fontSize: 14.0,
 );
-final TextStyle defaultTodayTextStyle = TextStyle(
+const TextStyle defaultTodayTextStyle = const TextStyle(
 	color: Colors.white,
 	fontSize: 14.0,
 );
-final TextStyle defaultSelectedDayTextStyle = TextStyle(
+const TextStyle defaultSelectedDayTextStyle = const TextStyle(
 	color: Colors.white,
 	fontSize: 14.0,
 );
-final TextStyle defaultWeekdayTextStyle = TextStyle(
+const TextStyle defaultWeekdayTextStyle = const TextStyle(
 	color: Colors.deepOrange,
 	fontSize: 14.0,
 );
-final TextStyle defaultWeekendTextStyle = TextStyle(
+const TextStyle defaultWeekendTextStyle = const TextStyle(
 	color: Colors.pinkAccent,
 	fontSize: 14.0,
 );
-final TextStyle defaultInactiveDaysTextStyle = TextStyle(
+const TextStyle defaultInactiveDaysTextStyle = const TextStyle(
 	color: Colors.black38,
 	fontSize: 14.0,
 );

--- a/lib/src/src.dart
+++ b/lib/src/src.dart
@@ -1,2 +1,0 @@
-
-export 'default_styles.dart';

--- a/lib/src/src.dart
+++ b/lib/src/src.dart
@@ -1,0 +1,2 @@
+
+export 'default_styles.dart';


### PR DESCRIPTION
Moved out text styles to their own file, also changed from final to const. There's no need to assign them at runtime as they don't change. with const they will be assigned at compile time

as discussed in #67