### PR TITLE
[WIP] Refactoring - Separate and Test Weekdays row

### DIFF
--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -217,8 +217,13 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
                 ? widget.onHeaderTitlePressed
                 : () => _selectDateFromPicker(),
           ),
-          WeekdayRow(widget.showWeekDays, widget.weekDayFormat,
-              widget.weekDayMargin, widget.weekdayTextStyle, _localeDate),
+          WeekdayRow(
+            showWeekdays: widget.showWeekDays,
+            weekdayFormat: widget.weekDayFormat,
+            weekDayMargin: widget.weekDayMargin,
+            weekdayTextStyle: widget.weekdayTextStyle,
+            localeDate: _localeDate,
+          ),
           Expanded(
               child: PageView.builder(
             itemCount: 3,

--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_calendar_carousel/classes/event_list.dart';
 import 'package:flutter_calendar_carousel/src/default_styles.dart';
 import 'package:flutter_calendar_carousel/src/calendar_header.dart';
+import 'package:flutter_calendar_carousel/src/weekday_row.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:intl/intl.dart' show DateFormat;
 
@@ -216,14 +217,13 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
                 ? widget.onHeaderTitlePressed
                 : () => _selectDateFromPicker(),
           ),
-          Container(
-            child: !widget.showWeekDays
-                ? Container()
-                : Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: _renderWeekDays(),
-                  ),
-          ),
+					WeekdayRow(
+						widget.showWeekDays,
+						widget.weekDayFormat,
+						widget.weekDayMargin,
+						widget.weekdayTextStyle,
+						_localeDate
+					),
           Expanded(
               child: PageView.builder(
             itemCount: 3,
@@ -786,58 +786,6 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
         widget.onCalendarChanged(this._dates[1]);
       });
     }
-  }
-
-  List<Widget> _renderWeekDays() {
-    List<Widget> list = [];
-
-    /// because of number of days in a week is 7, so it would be easier to count it til 7.
-    for (var i = firstDayOfWeek, count = 0;
-        count < 7;
-        i = (i + 1) % 7, count++) {
-      String weekDay;
-
-      switch (widget.weekDayFormat) {
-        case WeekdayFormat.weekdays:
-          weekDay = _localeDate.dateSymbols.WEEKDAYS[i];
-          break;
-        case WeekdayFormat.standalone:
-          weekDay = _localeDate.dateSymbols.STANDALONEWEEKDAYS[i];
-          break;
-        case WeekdayFormat.short:
-          weekDay = _localeDate.dateSymbols.SHORTWEEKDAYS[i];
-          break;
-        case WeekdayFormat.standaloneShort:
-          weekDay = _localeDate.dateSymbols.STANDALONESHORTWEEKDAYS[i];
-          break;
-        case WeekdayFormat.narrow:
-          weekDay = _localeDate.dateSymbols.NARROWWEEKDAYS[i];
-          break;
-        case WeekdayFormat.standaloneNarrow:
-          weekDay = _localeDate.dateSymbols.STANDALONENARROWWEEKDAYS[i];
-          break;
-        default:
-          weekDay = _localeDate.dateSymbols.STANDALONEWEEKDAYS[i];
-          break;
-      }
-
-      list.add(
-        Expanded(
-            child: Container(
-          margin: widget.weekDayMargin,
-          child: Center(
-            child: DefaultTextStyle(
-              style: defaultWeekdayTextStyle,
-              child: Text(
-                weekDay,
-                style: widget.weekdayTextStyle,
-              ),
-            ),
-          ),
-        )),
-      );
-    }
-    return list;
   }
 
   Widget _renderMarked(DateTime now) {

--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -220,7 +220,7 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
           WeekdayRow(
             showWeekdays: widget.showWeekDays,
             weekdayFormat: widget.weekDayFormat,
-            weekDayMargin: widget.weekDayMargin,
+            weekdayMargin: widget.weekDayMargin,
             weekdayTextStyle: widget.weekdayTextStyle,
             localeDate: _localeDate,
           ),

--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -217,13 +217,8 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
                 ? widget.onHeaderTitlePressed
                 : () => _selectDateFromPicker(),
           ),
-					WeekdayRow(
-						widget.showWeekDays,
-						widget.weekDayFormat,
-						widget.weekDayMargin,
-						widget.weekdayTextStyle,
-						_localeDate
-					),
+          WeekdayRow(widget.showWeekDays, widget.weekDayFormat,
+              widget.weekDayMargin, widget.weekdayTextStyle, _localeDate),
           Expanded(
               child: PageView.builder(
             itemCount: 3,

--- a/lib/src/weekday_row.dart
+++ b/lib/src/weekday_row.dart
@@ -8,19 +8,19 @@ class WeekdayRow extends StatelessWidget {
   WeekdayRow(
       {@required this.showWeekdays,
       @required this.weekdayFormat,
-      @required this.weekDayMargin,
+      @required this.weekdayMargin,
       @required this.weekdayTextStyle,
       @required this.localeDate});
 
   final bool showWeekdays;
   final WeekdayFormat weekdayFormat;
-  final EdgeInsets weekDayMargin;
+  final EdgeInsets weekdayMargin;
   final TextStyle weekdayTextStyle;
   final DateFormat localeDate;
 
   Widget _weekdayContainer(String weekDay) => Expanded(
           child: Container(
-        margin: weekDayMargin,
+        margin: weekdayMargin,
         child: Center(
           child: DefaultTextStyle(
             style: defaultWeekdayTextStyle,
@@ -32,7 +32,7 @@ class WeekdayRow extends StatelessWidget {
         ),
       ));
 
-  List<Widget> _generateWeekDays() {
+  List<Widget> _generateWeekdays() {
     switch (weekdayFormat) {
       case WeekdayFormat.weekdays:
         return localeDate.dateSymbols.WEEKDAYS
@@ -69,7 +69,7 @@ class WeekdayRow extends StatelessWidget {
   Widget build(BuildContext context) => showWeekdays
       ? Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: _generateWeekDays(),
+          children: _generateWeekdays(),
         )
       : Container();
 }

--- a/lib/src/weekday_row.dart
+++ b/lib/src/weekday_row.dart
@@ -5,8 +5,12 @@ import 'package:flutter_calendar_carousel/src/default_styles.dart'
 import 'package:intl/intl.dart';
 
 class WeekdayRow extends StatelessWidget {
-  WeekdayRow(this.showWeekdays, this.weekdayFormat, this.weekDayMargin,
-      this.weekdayTextStyle, this.localeDate);
+  WeekdayRow(
+      {@required this.showWeekdays,
+      @required this.weekdayFormat,
+      @required this.weekDayMargin,
+      @required this.weekdayTextStyle,
+      @required this.localeDate});
 
   final bool showWeekdays;
   final WeekdayFormat weekdayFormat;

--- a/lib/src/weekday_row.dart
+++ b/lib/src/weekday_row.dart
@@ -1,24 +1,14 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_calendar_carousel/flutter_calendar_carousel.dart';
 import 'package:flutter_calendar_carousel/src/default_styles.dart'
     show defaultWeekdayTextStyle;
 import 'package:intl/intl.dart';
 
-enum WeekdayFormat {
-  weekdays,
-  standalone,
-  short,
-  standaloneShort,
-  narrow,
-  standaloneNarrow,
-}
-
 class WeekdayRow extends StatelessWidget {
-  WeekdayRow(this.dateFormant, this.showWeekdays, this.weekdayFormat,
+  WeekdayRow(this.showWeekdays, this.weekdayFormat,
       this.weekDayMargin, this.weekdayTextStyle, this.localeDate);
 
   final bool showWeekdays;
-  final DateFormat dateFormant;
-  final int firstDayOfWeek = 0;
   final WeekdayFormat weekdayFormat;
   final EdgeInsets weekDayMargin;
   final TextStyle weekdayTextStyle;
@@ -43,37 +33,37 @@ class WeekdayRow extends StatelessWidget {
       case WeekdayFormat.weekdays:
         {
           return localeDate.dateSymbols.WEEKDAYS
-              .map<Widget>((day) => _weekdayContainer(day));
+              .map<Widget>((day) => _weekdayContainer(day)).toList();
         }
       case WeekdayFormat.standalone:
         {
           return localeDate.dateSymbols.STANDALONEWEEKDAYS
-              .map<Widget>((day) => _weekdayContainer(day));
+              .map<Widget>((day) => _weekdayContainer(day)).toList();
         }
       case WeekdayFormat.short:
         {
           return localeDate.dateSymbols.SHORTWEEKDAYS
-              .map<Widget>((day) => _weekdayContainer(day));
+              .map<Widget>((day) => _weekdayContainer(day)).toList();
         }
       case WeekdayFormat.standaloneShort:
         {
           return localeDate.dateSymbols.STANDALONESHORTWEEKDAYS
-              .map<Widget>((day) => _weekdayContainer(day));
+              .map<Widget>((day) => _weekdayContainer(day)).toList();
         }
       case WeekdayFormat.narrow:
         {
           return localeDate.dateSymbols.NARROWWEEKDAYS
-              .map<Widget>((day) => _weekdayContainer(day));
+              .map<Widget>((day) => _weekdayContainer(day)).toList();
         }
       case WeekdayFormat.standaloneNarrow:
         {
           return localeDate.dateSymbols.STANDALONENARROWWEEKDAYS
-              .map<Widget>((day) => _weekdayContainer(day));
+              .map<Widget>((day) => _weekdayContainer(day)).toList();
         }
       default:
         {
           return localeDate.dateSymbols.STANDALONEWEEKDAYS
-              .map<Widget>((day) => _weekdayContainer(day));
+              .map<Widget>((day) => _weekdayContainer(day)).toList();
         }
     }
   }

--- a/lib/src/weekday_row.dart
+++ b/lib/src/weekday_row.dart
@@ -5,8 +5,8 @@ import 'package:flutter_calendar_carousel/src/default_styles.dart'
 import 'package:intl/intl.dart';
 
 class WeekdayRow extends StatelessWidget {
-  WeekdayRow(this.showWeekdays, this.weekdayFormat,
-      this.weekDayMargin, this.weekdayTextStyle, this.localeDate);
+  WeekdayRow(this.showWeekdays, this.weekdayFormat, this.weekDayMargin,
+      this.weekdayTextStyle, this.localeDate);
 
   final bool showWeekdays;
   final WeekdayFormat weekdayFormat;
@@ -33,37 +33,44 @@ class WeekdayRow extends StatelessWidget {
       case WeekdayFormat.weekdays:
         {
           return localeDate.dateSymbols.WEEKDAYS
-              .map<Widget>((day) => _weekdayContainer(day)).toList();
+              .map<Widget>(_weekdayContainer)
+              .toList();
         }
       case WeekdayFormat.standalone:
         {
           return localeDate.dateSymbols.STANDALONEWEEKDAYS
-              .map<Widget>((day) => _weekdayContainer(day)).toList();
+              .map<Widget>(_weekdayContainer)
+              .toList();
         }
       case WeekdayFormat.short:
         {
           return localeDate.dateSymbols.SHORTWEEKDAYS
-              .map<Widget>((day) => _weekdayContainer(day)).toList();
+              .map<Widget>(_weekdayContainer)
+              .toList();
         }
       case WeekdayFormat.standaloneShort:
         {
           return localeDate.dateSymbols.STANDALONESHORTWEEKDAYS
-              .map<Widget>((day) => _weekdayContainer(day)).toList();
+              .map<Widget>(_weekdayContainer)
+              .toList();
         }
       case WeekdayFormat.narrow:
         {
           return localeDate.dateSymbols.NARROWWEEKDAYS
-              .map<Widget>((day) => _weekdayContainer(day)).toList();
+              .map<Widget>(_weekdayContainer)
+              .toList();
         }
       case WeekdayFormat.standaloneNarrow:
         {
           return localeDate.dateSymbols.STANDALONENARROWWEEKDAYS
-              .map<Widget>((day) => _weekdayContainer(day)).toList();
+              .map<Widget>(_weekdayContainer)
+              .toList();
         }
       default:
         {
           return localeDate.dateSymbols.STANDALONEWEEKDAYS
-              .map<Widget>((day) => _weekdayContainer(day)).toList();
+              .map<Widget>(_weekdayContainer)
+              .toList();
         }
     }
   }

--- a/lib/src/weekday_row.dart
+++ b/lib/src/weekday_row.dart
@@ -31,47 +31,33 @@ class WeekdayRow extends StatelessWidget {
   List<Widget> _generateWeekDays() {
     switch (weekdayFormat) {
       case WeekdayFormat.weekdays:
-        {
-          return localeDate.dateSymbols.WEEKDAYS
-              .map<Widget>(_weekdayContainer)
-              .toList();
-        }
+        return localeDate.dateSymbols.WEEKDAYS
+            .map<Widget>(_weekdayContainer)
+            .toList();
       case WeekdayFormat.standalone:
-        {
-          return localeDate.dateSymbols.STANDALONEWEEKDAYS
-              .map<Widget>(_weekdayContainer)
-              .toList();
-        }
+        return localeDate.dateSymbols.STANDALONEWEEKDAYS
+            .map<Widget>(_weekdayContainer)
+            .toList();
       case WeekdayFormat.short:
-        {
-          return localeDate.dateSymbols.SHORTWEEKDAYS
-              .map<Widget>(_weekdayContainer)
-              .toList();
-        }
+        return localeDate.dateSymbols.SHORTWEEKDAYS
+            .map<Widget>(_weekdayContainer)
+            .toList();
       case WeekdayFormat.standaloneShort:
-        {
-          return localeDate.dateSymbols.STANDALONESHORTWEEKDAYS
-              .map<Widget>(_weekdayContainer)
-              .toList();
-        }
+        return localeDate.dateSymbols.STANDALONESHORTWEEKDAYS
+            .map<Widget>(_weekdayContainer)
+            .toList();
       case WeekdayFormat.narrow:
-        {
-          return localeDate.dateSymbols.NARROWWEEKDAYS
-              .map<Widget>(_weekdayContainer)
-              .toList();
-        }
+        return localeDate.dateSymbols.NARROWWEEKDAYS
+            .map<Widget>(_weekdayContainer)
+            .toList();
       case WeekdayFormat.standaloneNarrow:
-        {
-          return localeDate.dateSymbols.STANDALONENARROWWEEKDAYS
-              .map<Widget>(_weekdayContainer)
-              .toList();
-        }
+        return localeDate.dateSymbols.STANDALONENARROWWEEKDAYS
+            .map<Widget>(_weekdayContainer)
+            .toList();
       default:
-        {
-          return localeDate.dateSymbols.STANDALONEWEEKDAYS
-              .map<Widget>(_weekdayContainer)
-              .toList();
-        }
+        return localeDate.dateSymbols.STANDALONEWEEKDAYS
+            .map<Widget>(_weekdayContainer)
+            .toList();
     }
   }
 

--- a/lib/src/weekday_row.dart
+++ b/lib/src/weekday_row.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_calendar_carousel/src/default_styles.dart'
+    show defaultWeekdayTextStyle;
+import 'package:intl/intl.dart';
+
+enum WeekdayFormat {
+  weekdays,
+  standalone,
+  short,
+  standaloneShort,
+  narrow,
+  standaloneNarrow,
+}
+
+class WeekdayRow extends StatelessWidget {
+  WeekdayRow(this.dateFormant, this.showWeekdays, this.weekdayFormat,
+      this.weekDayMargin, this.weekdayTextStyle, this.localeDate);
+
+  final bool showWeekdays;
+  final DateFormat dateFormant;
+  final int firstDayOfWeek = 0;
+  final WeekdayFormat weekdayFormat;
+  final EdgeInsets weekDayMargin;
+  final TextStyle weekdayTextStyle;
+  final DateFormat localeDate;
+
+  Widget _weekdayContainer(String weekDay) => Expanded(
+          child: Container(
+        margin: weekDayMargin,
+        child: Center(
+          child: DefaultTextStyle(
+            style: defaultWeekdayTextStyle,
+            child: Text(
+              weekDay,
+              style: weekdayTextStyle,
+            ),
+          ),
+        ),
+      ));
+
+  List<Widget> _generateWeekDays() {
+    switch (weekdayFormat) {
+      case WeekdayFormat.weekdays:
+        {
+          return localeDate.dateSymbols.WEEKDAYS
+              .map<Widget>((day) => _weekdayContainer(day));
+        }
+      case WeekdayFormat.standalone:
+        {
+          return localeDate.dateSymbols.STANDALONEWEEKDAYS
+              .map<Widget>((day) => _weekdayContainer(day));
+        }
+      case WeekdayFormat.short:
+        {
+          return localeDate.dateSymbols.SHORTWEEKDAYS
+              .map<Widget>((day) => _weekdayContainer(day));
+        }
+      case WeekdayFormat.standaloneShort:
+        {
+          return localeDate.dateSymbols.STANDALONESHORTWEEKDAYS
+              .map<Widget>((day) => _weekdayContainer(day));
+        }
+      case WeekdayFormat.narrow:
+        {
+          return localeDate.dateSymbols.NARROWWEEKDAYS
+              .map<Widget>((day) => _weekdayContainer(day));
+        }
+      case WeekdayFormat.standaloneNarrow:
+        {
+          return localeDate.dateSymbols.STANDALONENARROWWEEKDAYS
+              .map<Widget>((day) => _weekdayContainer(day));
+        }
+      default:
+        {
+          return localeDate.dateSymbols.STANDALONEWEEKDAYS
+              .map<Widget>((day) => _weekdayContainer(day));
+        }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) => showWeekdays
+      ? Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: _generateWeekDays(),
+        )
+      : Container();
+}

--- a/test/src/weekday_row_test.dart
+++ b/test/src/weekday_row_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter_calendar_carousel/flutter_calendar_carousel.dart' show WeekdayFormat;
+import 'package:flutter_calendar_carousel/flutter_calendar_carousel.dart'
+    show WeekdayFormat;
 import 'package:intl/intl.dart' show DateFormat;
 
 import 'package:flutter_calendar_carousel/src/weekday_row.dart';
@@ -10,13 +11,52 @@ void main() {
   final margin = const EdgeInsets.only(bottom: 4.0);
 
   testWidgets('test short weekday row', (WidgetTester tester) async {
-    await tester.pumpWidget(
-        wrapped(
-          WeekdayRow(true,
-              WeekdayFormat.short,
-              margin, null, format),
-        )
-    );
+    await tester.pumpWidget(wrapped(
+      WeekdayRow(true, WeekdayFormat.short, margin, null, format),
+    ));
+
+    expect(find.text('Sun'), findsOneWidget);
+    expect(find.text('Mon'), findsOneWidget);
+    expect(find.text('Tue'), findsOneWidget);
+    expect(find.text('Wed'), findsOneWidget);
+    expect(find.text('Thu'), findsOneWidget);
+    expect(find.text('Fri'), findsOneWidget);
+    expect(find.text('Sat'), findsOneWidget);
+  });
+
+  testWidgets('test narrow weekday row', (WidgetTester tester) async {
+    await tester.pumpWidget(wrapped(
+      WeekdayRow(true, WeekdayFormat.standaloneNarrow, margin, null, format),
+    ));
+
+    // sat and sun
+    expect(find.text('S'), findsNWidgets(2));
+    // thurs and tues
+    expect(find.text('T'), findsNWidgets(2));
+
+    expect(find.text('M'), findsOneWidget);
+    expect(find.text('W'), findsOneWidget);
+    expect(find.text('F'), findsOneWidget);
+  });
+
+  testWidgets('test standalone weekday row', (WidgetTester tester) async {
+    await tester.pumpWidget(wrapped(
+      WeekdayRow(true, WeekdayFormat.standalone, margin, null, format),
+    ));
+
+    expect(find.text('Sunday'), findsOneWidget);
+    expect(find.text('Monday'), findsOneWidget);
+    expect(find.text('Tuesday'), findsOneWidget);
+    expect(find.text('Wednesday'), findsOneWidget);
+    expect(find.text('Thursday'), findsOneWidget);
+    expect(find.text('Friday'), findsOneWidget);
+    expect(find.text('Saturday'), findsOneWidget);
+  });
+
+  testWidgets('test standalone short weekday row', (WidgetTester tester) async {
+    await tester.pumpWidget(wrapped(
+      WeekdayRow(true, WeekdayFormat.standaloneShort, margin, null, format),
+    ));
 
     expect(find.text('Sun'), findsOneWidget);
     expect(find.text('Mon'), findsOneWidget);
@@ -29,6 +69,6 @@ void main() {
 }
 
 Widget wrapped(Widget widget) => Directionality(
-  textDirection: TextDirection.ltr,
-  child: widget,
-);
+      textDirection: TextDirection.ltr,
+      child: widget,
+    );

--- a/test/src/weekday_row_test.dart
+++ b/test/src/weekday_row_test.dart
@@ -84,6 +84,16 @@ void main() {
     expect(find.text('Fri'), findsOneWidget);
     expect(find.text('Sat'), findsOneWidget);
   });
+
+  testWidgets('test row does not render', (WidgetTester tester) async {
+    final emptyContainer = WeekdayRow(showWeekdays: false);
+
+    await tester.pumpWidget(emptyContainer);
+
+    expect(find.byType(Container), findsOneWidget);
+
+    expect(find.byType(Row), findsNothing);
+  });
 }
 
 Widget wrapped(Widget widget) => Directionality(

--- a/test/src/weekday_row_test.dart
+++ b/test/src/weekday_row_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_calendar_carousel/flutter_calendar_carousel.dart' show WeekdayFormat;
+import 'package:intl/intl.dart';
+
+import 'package:flutter_calendar_carousel/src/weekday_row.dart';
+import 'package:flutter/material.dart';
+
+void main() {
+  final format = DateFormat.yMMM("en");
+  final margin = const EdgeInsets.only(bottom: 4.0);
+
+  testWidgets('test weekday row', (WidgetTester tester) async {
+    await tester.pumpWidget(
+        wrapped(
+          WeekdayRow(true,
+              WeekdayFormat.short,
+              margin, null, format),
+        ));
+  });
+}
+
+Widget wrapped(Widget widget) => MaterialApp(
+  home: Container(
+    child: Material(child: widget),
+  ),
+);

--- a/test/src/weekday_row_test.dart
+++ b/test/src/weekday_row_test.dart
@@ -1,26 +1,34 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_calendar_carousel/flutter_calendar_carousel.dart' show WeekdayFormat;
-import 'package:intl/intl.dart';
+import 'package:intl/intl.dart' show DateFormat;
 
 import 'package:flutter_calendar_carousel/src/weekday_row.dart';
 import 'package:flutter/material.dart';
 
 void main() {
-  final format = DateFormat.yMMM("en");
+  final format = DateFormat.yMMM("en_US");
   final margin = const EdgeInsets.only(bottom: 4.0);
 
-  testWidgets('test weekday row', (WidgetTester tester) async {
+  testWidgets('test short weekday row', (WidgetTester tester) async {
     await tester.pumpWidget(
         wrapped(
           WeekdayRow(true,
               WeekdayFormat.short,
               margin, null, format),
-        ));
+        )
+    );
+
+    expect(find.text('Sun'), findsOneWidget);
+    expect(find.text('Mon'), findsOneWidget);
+    expect(find.text('Tue'), findsOneWidget);
+    expect(find.text('Wed'), findsOneWidget);
+    expect(find.text('Thu'), findsOneWidget);
+    expect(find.text('Fri'), findsOneWidget);
+    expect(find.text('Sat'), findsOneWidget);
   });
 }
 
-Widget wrapped(Widget widget) => MaterialApp(
-  home: Container(
-    child: Material(child: widget),
-  ),
+Widget wrapped(Widget widget) => Directionality(
+  textDirection: TextDirection.ltr,
+  child: widget,
 );

--- a/test/src/weekday_row_test.dart
+++ b/test/src/weekday_row_test.dart
@@ -15,7 +15,7 @@ void main() {
       WeekdayRow(
         showWeekdays: true,
         weekdayFormat: WeekdayFormat.short,
-        weekDayMargin: margin,
+        weekdayMargin: margin,
         weekdayTextStyle: null,
         localeDate: locale,
       ),
@@ -34,7 +34,7 @@ void main() {
     await tester.pumpWidget(wrapped(WeekdayRow(
       showWeekdays: true,
       weekdayFormat: WeekdayFormat.standaloneNarrow,
-      weekDayMargin: margin,
+      weekdayMargin: margin,
       weekdayTextStyle: null,
       localeDate: locale,
     )));
@@ -53,7 +53,7 @@ void main() {
     await tester.pumpWidget(wrapped(WeekdayRow(
       showWeekdays: true,
       weekdayFormat: WeekdayFormat.standalone,
-      weekDayMargin: margin,
+      weekdayMargin: margin,
       weekdayTextStyle: null,
       localeDate: locale,
     )));
@@ -71,7 +71,7 @@ void main() {
     await tester.pumpWidget(wrapped(WeekdayRow(
       showWeekdays: true,
       weekdayFormat: WeekdayFormat.standaloneShort,
-      weekDayMargin: margin,
+      weekdayMargin: margin,
       weekdayTextStyle: null,
       localeDate: locale,
     )));

--- a/test/src/weekday_row_test.dart
+++ b/test/src/weekday_row_test.dart
@@ -7,12 +7,18 @@ import 'package:flutter_calendar_carousel/src/weekday_row.dart';
 import 'package:flutter/material.dart';
 
 void main() {
-  final format = DateFormat.yMMM("en_US");
+  final locale = DateFormat.yMMM("en_US");
   final margin = const EdgeInsets.only(bottom: 4.0);
 
   testWidgets('test short weekday row', (WidgetTester tester) async {
     await tester.pumpWidget(wrapped(
-      WeekdayRow(true, WeekdayFormat.short, margin, null, format),
+      WeekdayRow(
+        showWeekdays: true,
+        weekdayFormat: WeekdayFormat.short,
+        weekDayMargin: margin,
+        weekdayTextStyle: null,
+        localeDate: locale,
+      ),
     ));
 
     expect(find.text('Sun'), findsOneWidget);
@@ -25,9 +31,13 @@ void main() {
   });
 
   testWidgets('test narrow weekday row', (WidgetTester tester) async {
-    await tester.pumpWidget(wrapped(
-      WeekdayRow(true, WeekdayFormat.standaloneNarrow, margin, null, format),
-    ));
+    await tester.pumpWidget(wrapped(WeekdayRow(
+      showWeekdays: true,
+      weekdayFormat: WeekdayFormat.standaloneNarrow,
+      weekDayMargin: margin,
+      weekdayTextStyle: null,
+      localeDate: locale,
+    )));
 
     // sat and sun
     expect(find.text('S'), findsNWidgets(2));
@@ -40,9 +50,13 @@ void main() {
   });
 
   testWidgets('test standalone weekday row', (WidgetTester tester) async {
-    await tester.pumpWidget(wrapped(
-      WeekdayRow(true, WeekdayFormat.standalone, margin, null, format),
-    ));
+    await tester.pumpWidget(wrapped(WeekdayRow(
+      showWeekdays: true,
+      weekdayFormat: WeekdayFormat.standalone,
+      weekDayMargin: margin,
+      weekdayTextStyle: null,
+      localeDate: locale,
+    )));
 
     expect(find.text('Sunday'), findsOneWidget);
     expect(find.text('Monday'), findsOneWidget);
@@ -54,9 +68,13 @@ void main() {
   });
 
   testWidgets('test standalone short weekday row', (WidgetTester tester) async {
-    await tester.pumpWidget(wrapped(
-      WeekdayRow(true, WeekdayFormat.standaloneShort, margin, null, format),
-    ));
+    await tester.pumpWidget(wrapped(WeekdayRow(
+      showWeekdays: true,
+      weekdayFormat: WeekdayFormat.standaloneShort,
+      weekDayMargin: margin,
+      weekdayTextStyle: null,
+      localeDate: locale,
+    )));
 
     expect(find.text('Sun'), findsOneWidget);
     expect(find.text('Mon'), findsOneWidget);


### PR DESCRIPTION
As discussed in #67

@hyochan I'm not sure about your comment `When FIRSTDAYOFWEEK is 0 in dart-intl, it represents Monday.` but I found that when using weekdays from `dateSymbols` Sunday is the first day, you can check it out [here](https://github.com/dart-lang/intl/blob/461bea33a0ad336b29739a27f0e6e29546bd1718/lib/date_symbols.dart#L298) 

So I went ahead and omitted using `firstDayOfWeek` like you were previously doing. 