### PR TITLE
Pass first date of week to onCalendarChanged in week view

### DIFF
--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -777,7 +777,7 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
     if (this._dates.length == 3 && widget.onCalendarChanged != null) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         _isReloadSelectedDate = false;
-        widget.onCalendarChanged(this._dates[1]);
+        widget.onCalendarChanged(!widget.weekFormat ? this._dates[1] : this._weeks[1][firstDayOfWeek]);
       });
     }
   }


### PR DESCRIPTION
Hi,

Currently, I see that when the calendar is in week format, the input date of onCalendarChanged is unchanged even when we navigate to the weeks of different month. This PR is to pass the first date of week to onCalendarChanged when we navigate between the weeks in week view.

Please help to take a look and see that if my proposed fix is correct.

Thanks,
Duy