### PR TITLE
Release/1.3.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 + Support semantic label as a feature request [#139](https://github.com/dooboolab/flutter_calendar_carousel/issues/139)
 + Expose `dayCrossAxisAlignment` and `dayMainAxisAlignment` to resolve [#122](https://github.com/dooboolab/flutter_calendar_carousel/issues/122)
 + Expose `showIconBehindDayText` to resolve [#131](https://github.com/dooboolab/flutter_calendar_carousel/issues/131)
++ Fixes [#94](https://github.com/dooboolab/flutter_calendar_carousel/issues/94)
 ## [1.3.20]
 + Support intl >= 0.15.7
 ## [1.3.19]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [1.3.21]
+## [1.3.23]
 + Support intl >= 0.15.7 < 0.17.0 to inclease `pub` health
 + Removed deprecated methods ~~`markedDates`~~, ~~`markedDateColor`~~
 + Fixes [#101](https://github.com/dooboolab/flutter_calendar_carousel/issues/101)
@@ -6,6 +6,8 @@
 + Fixes [#112](https://github.com/dooboolab/flutter_calendar_carousel/issues/112)
 + Fixes [#119](https://github.com/dooboolab/flutter_calendar_carousel/issues/119)
 + Support long pressed as a feature request[#103](https://github.com/dooboolab/flutter_calendar_carousel/issues/103)
++ Support semantic label as a feature request [#139](https://github.com/dooboolab/flutter_calendar_carousel/issues/139)
++ Expose `dayCrossAxisAlignment` and `dayMainAxisAlignment` to resolve [#122](https://github.com/dooboolab/flutter_calendar_carousel/issues/122)
 ## [1.3.20]
 + Support intl >= 0.15.7
 ## [1.3.19]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 + Support long pressed as a feature request[#103](https://github.com/dooboolab/flutter_calendar_carousel/issues/103)
 + Support semantic label as a feature request [#139](https://github.com/dooboolab/flutter_calendar_carousel/issues/139)
 + Expose `dayCrossAxisAlignment` and `dayMainAxisAlignment` to resolve [#122](https://github.com/dooboolab/flutter_calendar_carousel/issues/122)
++ Expose `showIconBehindDayText` to resolve [#131](https://github.com/dooboolab/flutter_calendar_carousel/issues/131)
 ## [1.3.20]
 + Support intl >= 0.15.7
 ## [1.3.19]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## [1.3.21]
 + Support intl >= 0.15.7 < 0.17.0 to inclease `pub` health
 + Removed deprecated methods ~~`markedDates`~~, ~~`markedDateColor`~~
++ Fixes [#101](https://github.com/dooboolab/flutter_calendar_carousel/issues/101)
++ Fixes [#104](https://github.com/dooboolab/flutter_calendar_carousel/issues/104)
++ Fixes [#112](https://github.com/dooboolab/flutter_calendar_carousel/issues/112)
++ Fixes [#119](https://github.com/dooboolab/flutter_calendar_carousel/issues/119)
++ Support long pressed as a feature request[#103](https://github.com/dooboolab/flutter_calendar_carousel/issues/103)
 ## [1.3.20]
 + Support intl >= 0.15.7
 ## [1.3.19]

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ For help getting started with Flutter, view our online
 | weekDayFormat           | `WeekdayFormat` | `short` |
 | staticSixWeekFormat     | `bool`          | `false` |
 | showOnlyCurrentMonthDate | `bool`          | `false` |
+| dayCrossAxisAlignment | `CrossAxisAlignment` | `CrossAxisAlignment.center` |
+| dayMainAxisAlignment | `MainAxisAlignment` | `CrossAlignment.center` |
 
 With ``CalendarCarousel<YourEventClass>`` and ``EventList<YourEventClass>`` you can specifiy a custom Event class.
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ For help getting started with Flutter, view our online
 | showOnlyCurrentMonthDate | `bool`          | `false` |
 | dayCrossAxisAlignment | `CrossAxisAlignment` | `CrossAxisAlignment.center` |
 | dayMainAxisAlignment | `MainAxisAlignment` | `CrossAlignment.center` |
+| showIconBehindDayText | `bool` | `false` |
 
 With ``CalendarCarousel<YourEventClass>`` and ``EventList<YourEventClass>`` you can specifiy a custom Event class.
 

--- a/README.md
+++ b/README.md
@@ -28,59 +28,61 @@ For help getting started with Flutter, view our online
 ## Props
 | props                   | types           | defaultValues                                                                                                     |
 | :---------------------- | :-------------: | :---------------------------------------------------------------------------------------------------------------: |
-| viewPortFraction        | `double`        | 1.0                                                                                                               |
-| prevDaysTextStyle       | `TextStyle`     |                                                                                                                   |
-| daysTextStyle           | `TextStyle`     |                                                                                                                   |
-| nextDaysTextStyle       | `TextStyle`     |                                                                                                                   |
-| prevMonthDayBorderColor | `Color`         | Colors.transparent                                                                                                |
-| thisMonthDayBorderColor | `Color`         | Colors.transparent                                                                                                |
-| nextMonthDayBorderColor | `Color`         | Colors.transparent                                                                                                |
-| dayPadding              | `double`        | 2.0                                                                                                               |
-| height                  | `double`        | double.infinity                                                                                                   |
-| width                   | `double`        | double.infinity                                                                                                   |
-| todayTextStyle          | `TextStyle`     | `fontSize: 14.0, color: Colors.white`                                                                             |
-| dayButtonColor          | `Color`         | Colors.red                                                                                                        |
-| todayBorderColor        | `Color`         | Colors.red                                                                                                        |
-| todayButtonColor        | `Colors`        | Colors.red                                                                                                        |
-| selectedDateTime        | `DateTime`      |                                                                                                                   |
-| selectedDayTextStyle    | `TextStyle`     | `fontSize: 14.0, color: Colors.white`                                                                             |
-| selectedDayBorderColor  | `Color`         | Colors.green                                                                                                      |
-| selectedDayButtonColor  | `Color`         | Colors.green                                                                                                      |
-| daysHaveCircularBorder  | `bool`          |                                                                                                                   |
-| onDayPressed            | `Func`          |                                                                                                                   |
-| weekdayTextStyle        | `TextStyle`     | `fontSize: 14.0, color: Colors.deepOrange`                                                                        |
-| iconColor               | `Color`         | Colors.blueAccent                                                                                                 |
-| headerTextStyle         | `TextStyle`     | `fontSize: 20.0, color: Colors.blue`                                                                              |
-| headerText              | `Text`          | `Text('${DateFormat.yMMM().format(this._dates[1])}'`)                                                             |
-| weekendTextStyle        | `TextStyle`     | `fontSize: 14.0, color: Colors.pinkAccent`                                                                        |
-| markedDatesMap          | `Events`        | `null`                                                                                                            |
+| viewPortFraction        | `double`        | 1.0 |
+| prevDaysTextStyle       | `TextStyle`     | |
+| daysTextStyle           | `TextStyle`     | |
+| nextDaysTextStyle       | `TextStyle`     | |
+| prevMonthDayBorderColor | `Color`         | Colors.transparent |
+| thisMonthDayBorderColor | `Color`         | Colors.transparent |
+| nextMonthDayBorderColor | `Color`         | Colors.transparent |
+| dayPadding              | `double`        | 2.0 |
+| height                  | `double`        | double.infinity |
+| width                   | `double`        | double.infinity |
+| todayTextStyle          | `TextStyle`     | `fontSize: 14.0, color: Colors.white` |
+| dayButtonColor          | `Color`         | Colors.red |
+| todayBorderColor        | `Color`         | Colors.red |
+| todayButtonColor        | `Colors`        | Colors.red |
+| selectedDateTime        | `DateTime`      | |
+| selectedDayTextStyle    | `TextStyle`     | `fontSize: 14.0, color: Colors.white` |
+| selectedDayBorderColor  | `Color`         | Colors.green |
+| selectedDayButtonColor  | `Color`         | Colors.green |
+| daysHaveCircularBorder  | `bool`          | |
+| onDayPressed            | `Func`          | |
+| weekdayTextStyle        | `TextStyle`     | `fontSize: 14.0, color: Colors.deepOrange` |
+| iconColor               | `Color`         | Colors.blueAccent |
+| headerTextStyle         | `TextStyle`     | `fontSize: 20.0, color: Colors.blue` |
+| headerText              | `Text`          | `Text('${DateFormat.yMMM().format(this._dates[1])}'`) |
+| weekendTextStyle        | `TextStyle`     | `fontSize: 14.0, color: Colors.pinkAccent` |
+| markedDatesMap          | `Events`        | `null` |
 | markedDateWidget        | `Color`         | ``` Positioned(child: Container(color: Colors.blueAccent, height: 4.0, width: 4.0), bottom: 4.0, left: 18.0); ``` |
-| markedDateShowIcon      | `bool`          | false                                                                                                             |
-| markedDateIconBorderColor | `Color`       |                                                                                                                   |
-| markedDateIconMaxShown  | `int`           | 2                                                                                                                 |
-| markedDateIconMargin    | `double`        | 5.0                                                                                                               |
-| markedDateIconBuilder   | `MarkedDateIconBuilder<T>` |                                                                                                        |
-| markedDateIconOffset    | `double`        | 5.0                                                                                                               |
-| markedDateMoreCustomDecoration | `Decoration` |                                                                                                               |
-| markedDateMoreCustomTextStyle | `TextStyle` |                                                                                                                 |
-| headerMargin            | `EdgetInsets`   | `const EdgeInsets.symmetric(vertical: 16.0)`                                                                      |
-| headerTitleTouchable    | `bool`          | `false`                                                                                                           |
-| onHeaderTitlePressed    | `Function`      | `() => _selectDateFromPicker()`                                                                                   |
-| showHeader              | `bool`          |                                                                                                                   |
-| showHeaderButton        | `bool`          |                                                                                                                   |
-| childAspectRatio        | `double`        | `1.0`                                                                                                             |
-| weekDayMargin           | `EdgeInsets`    | `const EdgeInsets.only(bottom: 4.0)`                                                                              |
-| weekFormat              | `bool`          | `false`                                                                                                           |
-| locale                  | `String`        | `en`                                                                                                              |
-| firstDayOfWeek          | `int`           | `null`                                                                                                            |
-| onCalendarChanged       | `Function(DateTime)` |                                                                                                              |
-| minSelectedDate         | `DateTime`      |                                                                                                                   |
-| maxSelectedDate         | `DateTime`      |                                                                                                                   |
-| inactiveDaysTextStyle   | `TextStyle`     |                                                                                                                   |
-| inactiveWeekendTextStyle | `TextStyle`    |                                                                                                                   |
-| weekDayFormat           | `WeekdayFormat` | `short`                                                                                                           |
-| staticSixWeekFormat     | `bool`          | `false`                                                                                                           |
-| showOnlyCurrentMonthDate | `bool`          | `false`                                                                                                           |
+| markedDateShowIcon      | `bool`          | false |
+| markedDateIconBorderColor | `Color`       | |
+| markedDateIconMaxShown  | `int`           | 2 |
+| markedDateIconMargin    | `double`        | 5.0 |
+| markedDateIconBuilder   | `MarkedDateIconBuilder<T>` | |
+| markedDateIconOffset    | `double`        | 5.0 |
+| markedDateCustomShapeBorder | `ShapeBorder` | null |
+| markedDateCustomTextStyle | `TextStyle` | null |
+| markedDateMoreCustomDecoration | `Decoration` |    |
+| markedDateMoreCustomTextStyle | `TextStyle` |   |
+| headerMargin            | `EdgetInsets`   | `const EdgeInsets.symmetric(vertical: 16.0)` |
+| headerTitleTouchable    | `bool`          | `false` |
+| onHeaderTitlePressed    | `Function`      | `() => _selectDateFromPicker()` |
+| showHeader              | `bool`          | |
+| showHeaderButton        | `bool`          | |
+| childAspectRatio        | `double`        | `1.0` |
+| weekDayMargin           | `EdgeInsets`    | `const EdgeInsets.only(bottom: 4.0)` |
+| weekFormat              | `bool`          | `false` |
+| locale                  | `String`        | `en` |
+| firstDayOfWeek          | `int`           | `null` |
+| onCalendarChanged       | `Function(DateTime)` | |
+| minSelectedDate         | `DateTime`      | |
+| maxSelectedDate         | `DateTime`      | |
+| inactiveDaysTextStyle   | `TextStyle`     | |
+| inactiveWeekendTextStyle | `TextStyle`    | |
+| weekDayFormat           | `WeekdayFormat` | `short` |
+| staticSixWeekFormat     | `bool`          | `false` |
+| showOnlyCurrentMonthDate | `bool`          | `false` |
 
 With ``CalendarCarousel<YourEventClass>`` and ``EventList<YourEventClass>`` you can specifiy a custom Event class.
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -161,9 +161,7 @@ class _MyHomePageState extends State<MyHomePage> {
       ),
       thisMonthDayBorderColor: Colors.grey,
 //          weekDays: null, /// for pass null when you do not want to render weekDays
-//          headerText: Container( /// Example for rendering custom header
-//            child: Text('Custom Header'),
-//          ),
+      headerText: 'Custom Header',
 //          markedDates: _markedDate,
       weekFormat: true,
       markedDatesMap: _markedDateMap,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -173,6 +173,7 @@ class _MyHomePageState extends State<MyHomePage> {
       markedDateIconBuilder: (event) {
         return event.icon;
       },
+      todayButtonColor: Colors.transparent,
       todayBorderColor: Colors.green,
       markedDateMoreShowTotal:
           false, // null for not showing hidden events indicator
@@ -187,6 +188,7 @@ class _MyHomePageState extends State<MyHomePage> {
         this.setState(() => _currentDate2 = date);
         events.forEach((event) => print(event.title));
       },
+      daysHaveCircularBorder: true,
       weekendTextStyle: TextStyle(
         color: Colors.red,
       ),
@@ -196,14 +198,19 @@ class _MyHomePageState extends State<MyHomePage> {
       height: 420.0,
       selectedDateTime: _currentDate2,
       customGridViewPhysics: NeverScrollableScrollPhysics(),
-      markedDateShowIcon: true,
-      markedDateIconMaxShown: 2,
-      markedDateMoreShowTotal:
-          false, // null for not showing hidden events indicator
+      markedDateCustomShapeBorder: CircleBorder(
+        side: BorderSide(color: Colors.yellow)
+      ),
+      markedDateCustomTextStyle: TextStyle(
+        fontSize: 18,
+        color: Colors.blue,
+      ),
       showHeader: false,
-      markedDateIconBuilder: (event) {
-        return event.icon;
-      },
+      // markedDateIconBuilder: (event) {
+      //   return Container(
+      //     color: Colors.blue,
+      //   );
+      // },
       todayTextStyle: TextStyle(
         color: Colors.blue,
       ),
@@ -211,8 +218,8 @@ class _MyHomePageState extends State<MyHomePage> {
       selectedDayTextStyle: TextStyle(
         color: Colors.yellow,
       ),
-      minSelectedDate: _currentDate,
-      maxSelectedDate: _currentDate.add(Duration(days: 60)),
+      minSelectedDate: _currentDate.subtract(Duration(days: 360)),
+      maxSelectedDate: _currentDate.add(Duration(days: 360)),
 //      inactiveDateColor: Colors.black12,
       onCalendarChanged: (DateTime date) {
         this.setState(() => _currentMonth = DateFormat.yMMM().format(date));

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -169,6 +169,7 @@ class _MyHomePageState extends State<MyHomePage> {
       markedDatesMap: _markedDateMap,
       height: 200.0,
       selectedDateTime: _currentDate2,
+      showIconBehindDayText: true,
 //          daysHaveCircularBorder: false, /// null for not rendering any border, true for circular border, false for rectangular border
       customGridViewPhysics: NeverScrollableScrollPhysics(),
       markedDateShowIcon: true,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -71,6 +71,12 @@ class _MyHomePageState extends State<MyHomePage> {
           date: new DateTime(2019, 2, 10),
           title: 'Event 1',
           icon: _eventIcon,
+          dot: Container(
+            margin: EdgeInsets.symmetric(horizontal: 1.0),
+            color: Colors.red,
+            height: 5.0,
+            width: 5.0,
+          ),
         ),
         new Event(
           date: new DateTime(2019, 2, 10),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -179,6 +179,8 @@ class _MyHomePageState extends State<MyHomePage> {
       markedDateIconBuilder: (event) {
         return event.icon;
       },
+      minSelectedDate: _currentDate.subtract(Duration(days: 180)),
+      maxSelectedDate: _currentDate.add(Duration(days: 180)),
       todayButtonColor: Colors.transparent,
       todayBorderColor: Colors.green,
       markedDateMoreShowTotal:
@@ -224,9 +226,16 @@ class _MyHomePageState extends State<MyHomePage> {
       selectedDayTextStyle: TextStyle(
         color: Colors.yellow,
       ),
-      minSelectedDate: _currentDate.subtract(Duration(days: 360)),
-      maxSelectedDate: _currentDate.add(Duration(days: 360)),
-//      inactiveDateColor: Colors.black12,
+      minSelectedDate: _currentDate.subtract(Duration(days: 180)),
+      maxSelectedDate: _currentDate.add(Duration(days: 180)),
+      prevDaysTextStyle: TextStyle(
+        fontSize: 16,
+        color: Colors.pinkAccent,
+      ),
+      inactiveDaysTextStyle: TextStyle(
+        color: Colors.tealAccent,
+        fontSize: 16,
+      ),
       onCalendarChanged: (DateTime date) {
         this.setState(() => _currentMonth = DateFormat.yMMM().format(date));
       },

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -242,6 +242,9 @@ class _MyHomePageState extends State<MyHomePage> {
       onCalendarChanged: (DateTime date) {
         this.setState(() => _currentMonth = DateFormat.yMMM().format(date));
       },
+      onDayLongPressed: (DateTime date) {
+        print('long pressed date $date');
+      },
     );
 
     return new Scaffold(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -173,14 +173,17 @@ class _MyHomePageState extends State<MyHomePage> {
       customGridViewPhysics: NeverScrollableScrollPhysics(),
       markedDateShowIcon: true,
       markedDateIconMaxShown: 2,
+      selectedDayTextStyle: TextStyle(
+        color: Colors.yellow,
+      ),
       todayTextStyle: TextStyle(
         color: Colors.blue,
       ),
       markedDateIconBuilder: (event) {
         return event.icon;
       },
-      minSelectedDate: _currentDate.subtract(Duration(days: 180)),
-      maxSelectedDate: _currentDate.add(Duration(days: 180)),
+      minSelectedDate: _currentDate.subtract(Duration(days: 360)),
+      maxSelectedDate: _currentDate.add(Duration(days: 360)),
       todayButtonColor: Colors.transparent,
       todayBorderColor: Colors.green,
       markedDateMoreShowTotal:
@@ -226,8 +229,8 @@ class _MyHomePageState extends State<MyHomePage> {
       selectedDayTextStyle: TextStyle(
         color: Colors.yellow,
       ),
-      minSelectedDate: _currentDate.subtract(Duration(days: 180)),
-      maxSelectedDate: _currentDate.add(Duration(days: 180)),
+      minSelectedDate: _currentDate.subtract(Duration(days: 360)),
+      maxSelectedDate: _currentDate.add(Duration(days: 360)),
       prevDaysTextStyle: TextStyle(
         fontSize: 16,
         color: Colors.pinkAccent,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -82,7 +82,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.22"
+    version: "1.3.23"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/lib/classes/event.dart
+++ b/lib/classes/event.dart
@@ -4,14 +4,22 @@ class Event {
   final DateTime date;
   final String title;
   final Widget icon;
+  final Widget dot;
 
-  Event({this.date, this.title, this.icon}) : assert(date != null);
+  Event({
+    this.date,
+    this.title,
+    this.icon,
+    this.dot,
+  })
+  : assert(date != null);
 
   @override
   bool operator ==(dynamic other) {
     return this.date == other.date &&
         this.title == other.title &&
-        this.icon == other.icon;
+        this.icon == other.icon &&
+        this.dot == other.dot;
   }
 
   @override

--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -428,7 +428,9 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
                         children: <Widget>[
                           Center(
                             child: DefaultTextStyle(
-                              style: (_localeDate.dateSymbols.WEEKENDRANGE.contains(
+                              style: !isSelectable
+                              ?  defaultInactiveDaysTextStyle
+                              : (_localeDate.dateSymbols.WEEKENDRANGE.contains(
                                   (index - 1 + firstDayOfWeek) % 7)) && !isSelectedDay && !isToday
                                 ? (isPrevMonthDay
                                   ? defaultPrevDaysTextStyle
@@ -441,32 +443,30 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
                                   ? defaultTodayTextStyle
                                   : isSelectable && textStyle != null
                                       ? textStyle
-                                      : defaultTextStyle != null
-                                        ? defaultTextStyle
-                                        : defaultInactiveDaysTextStyle,
-                              child: Text(
-                                '${now.day}',
-                                style: (_localeDate.dateSymbols.WEEKENDRANGE.contains(
-                                  (index - 1 + firstDayOfWeek) % 7))
-                                  && !isSelectedDay
-                                  && isThisMonthDay
-                                  && !isToday
-                                  ? (isSelectable
-                                      ? widget.weekendTextStyle
-                                      : widget.inactiveWeekendTextStyle)
-                                  : isPrevMonthDay
-                                      ? widget.prevDaysTextStyle
-                                      : isNextMonthDay
-                                        ? widget.nextDaysTextStyle
-                                        : isSelectedDay
-                                            ? widget.selectedDayTextStyle
-                                            : isToday
-                                                ? widget.todayTextStyle
-                                                : isSelectable
-                                                  ? widget.daysTextStyle
-                                                  : widget.inactiveDaysTextStyle,
-                                maxLines: 1,
-                              ),
+                                      : defaultTextStyle,
+                                child: Text(
+                                  '${now.day}',
+                                  style: (_localeDate.dateSymbols.WEEKENDRANGE.contains(
+                                    (index - 1 + firstDayOfWeek) % 7))
+                                    && !isSelectedDay
+                                    && isThisMonthDay
+                                    && !isToday
+                                    ? (isSelectable
+                                        ? widget.weekendTextStyle
+                                        : widget.inactiveWeekendTextStyle)
+                                    : !isSelectable
+                                    ? widget.inactiveDaysTextStyle
+                                    : isPrevMonthDay
+                                        ? widget.prevDaysTextStyle
+                                        : isNextMonthDay
+                                          ? widget.nextDaysTextStyle
+                                          : isSelectedDay
+                                              ? widget.selectedDayTextStyle
+                                              : isToday
+                                                  ? widget.todayTextStyle
+                                                  : widget.daysTextStyle,
+                                  maxLines: 1,
+                                ),
                             ),
                           ),
                           widget.markedDatesMap != null
@@ -626,15 +626,17 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
                                         : defaultTextStyle,
                                 child: Text(
                                   '${now.day}',
-                                  style: (index % 7 == 0 || index % 7 == 6) &&
-                                    !isSelectedDay &&
-                                    !isToday
-                                    ? widget.weekendTextStyle
-                                    : isToday
-                                      ? widget.todayTextStyle
-                                      : isSelectable
-                                        ? textStyle
-                                        : widget.inactiveDaysTextStyle,
+                                  style: !isSelectable && widget.inactiveDaysTextStyle != null
+                                    ? widget.inactiveDaysTextStyle
+                                    : !isSelectable
+                                      ? defaultInactiveDaysTextStyle
+                                      : (index % 7 == 0 || index % 7 == 6) &&
+                                      !isSelectedDay &&
+                                      !isToday
+                                        ? widget.weekendTextStyle
+                                        : isToday
+                                          ? widget.todayTextStyle
+                                          : textStyle,
                                   maxLines: 1,
                                 ),
                               ),

--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -41,18 +41,24 @@ class CalendarCarousel<T> extends StatefulWidget {
   final Widget headerText;
   final TextStyle weekendTextStyle;
   final EventList<T> markedDatesMap;
+  /// Change `makredDateWidget` when `markedDateShowIcon` is set to false.
   final Widget markedDateWidget;
+  /// Change `ShapeBorder` when `markedDateShowIcon` is set to false.
+  final ShapeBorder markedDateCustomShapeBorder;
+  /// Change `TextStyle` when `markedDateShowIcon` is set to false.
+  final TextStyle markedDateCustomTextStyle;
+
+  /// Icon will overlap the [Day] widget when `markedDateShowIcon` is set to true.
+  /// This will also make below parameters work.
   final bool markedDateShowIcon;
   final Color markedDateIconBorderColor;
   final int markedDateIconMaxShown;
   final double markedDateIconMargin;
   final double markedDateIconOffset;
   final MarkedDateIconBuilder<T> markedDateIconBuilder;
-  final bool
-      markedDateMoreShowTotal; // null - no indicator, true - show the total events, false - show the total of hidden events
+  /// null - no indicator, true - show the total events, false - show the total of hidden events
+  final bool markedDateMoreShowTotal;
   final Decoration markedDateMoreCustomDecoration;
-  final ShapeBorder markedDateCustomShapeBorder;
-  final TextStyle markedDateCustomTextStyle;
   final TextStyle markedDateMoreCustomTextStyle;
   final EdgeInsets headerMargin;
   final double childAspectRatio;

--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -90,6 +90,8 @@ class CalendarCarousel<T> extends StatefulWidget {
   final bool showOnlyCurrentMonthDate;
   final bool pageSnapping;
   final OnDayLongPressed onDayLongPressed;
+  final CrossAxisAlignment dayCrossAxisAlignment;
+  final MainAxisAlignment dayMainAxisAlignment;
 
   CalendarCarousel({
     this.viewportFraction = 1.0,
@@ -158,6 +160,8 @@ class CalendarCarousel<T> extends StatefulWidget {
     this.showOnlyCurrentMonthDate = false,
     this.pageSnapping = false,
     this.onDayLongPressed,
+    this.dayCrossAxisAlignment = CrossAxisAlignment.center,
+    this.dayMainAxisAlignment = MainAxisAlignment.center,
   });
 
   @override
@@ -284,7 +288,7 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
     );
   }
 
-  DefaultTextStyle getDefaultTextStyle(
+  Widget getDayContainer(
     bool isSelectable,
     int index,
     bool isSelectedDay,
@@ -296,48 +300,58 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
     bool isThisMonthDay,
     DateTime now,
   ) {
-    return DefaultTextStyle(
-      style: !isSelectable
-      ?  defaultInactiveDaysTextStyle
-      : (_localeDate.dateSymbols.WEEKENDRANGE.contains(
-          (index - 1 + firstDayOfWeek) % 7)) && !isSelectedDay && !isToday
-        ? (isPrevMonthDay
-          ? defaultPrevDaysTextStyle
-          : isNextMonthDay
-            ? defaultNextDaysTextStyle
-            : isSelectable
-              ? defaultWeekendTextStyle
-              : defaultInactiveWeekendTextStyle)
-        : isToday
-          ? defaultTodayTextStyle
-          : isSelectable && textStyle != null
-              ? textStyle
-              : defaultTextStyle,
-        child: Text(
-          '${now.day}',
-          semanticsLabel: now.day.toString(),
-          style:
-            isSelectedDay && widget.selectedDayTextStyle != null
-            ? widget.selectedDayTextStyle
+    return Container(
+      width: double.infinity,
+      height: double.infinity,
+      child: Row(
+        crossAxisAlignment: widget.dayCrossAxisAlignment,
+        mainAxisAlignment: widget.dayMainAxisAlignment,
+        children: <Widget>[
+          DefaultTextStyle(
+            style: !isSelectable
+            ?  defaultInactiveDaysTextStyle
             : (_localeDate.dateSymbols.WEEKENDRANGE.contains(
-            (index - 1 + firstDayOfWeek) % 7))
-            && !isSelectedDay
-            && isThisMonthDay
-            && !isToday
-            ? (isSelectable
-                ? widget.weekendTextStyle
-                : widget.inactiveWeekendTextStyle)
-            : !isSelectable
-            ? widget.inactiveDaysTextStyle
-            : isPrevMonthDay
-                ? widget.prevDaysTextStyle
+                (index - 1 + firstDayOfWeek) % 7)) && !isSelectedDay && !isToday
+              ? (isPrevMonthDay
+                ? defaultPrevDaysTextStyle
                 : isNextMonthDay
-                  ? widget.nextDaysTextStyle
-                  : isToday
-                      ? widget.todayTextStyle
-                      : widget.daysTextStyle,
-          maxLines: 1,
-        ),
+                  ? defaultNextDaysTextStyle
+                  : isSelectable
+                    ? defaultWeekendTextStyle
+                    : defaultInactiveWeekendTextStyle)
+              : isToday
+                ? defaultTodayTextStyle
+                : isSelectable && textStyle != null
+                    ? textStyle
+                    : defaultTextStyle,
+              child: Text(
+                '${now.day}',
+                semanticsLabel: now.day.toString(),
+                style:
+                  isSelectedDay && widget.selectedDayTextStyle != null
+                  ? widget.selectedDayTextStyle
+                  : (_localeDate.dateSymbols.WEEKENDRANGE.contains(
+                  (index - 1 + firstDayOfWeek) % 7))
+                  && !isSelectedDay
+                  && isThisMonthDay
+                  && !isToday
+                  ? (isSelectable
+                      ? widget.weekendTextStyle
+                      : widget.inactiveWeekendTextStyle)
+                  : !isSelectable
+                  ? widget.inactiveDaysTextStyle
+                  : isPrevMonthDay
+                      ? widget.prevDaysTextStyle
+                      : isNextMonthDay
+                        ? widget.nextDaysTextStyle
+                        : isToday
+                            ? widget.todayTextStyle
+                            : widget.daysTextStyle,
+                maxLines: 1,
+              ),
+          ),
+        ],
+      ),
     );
   }
 
@@ -401,9 +415,7 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
                   ),
           child: Stack(
             children: <Widget>[
-              Center(
-                child: getDefaultTextStyle(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay, textStyle, defaultTextStyle, isNextMonthDay, isThisMonthDay, now),
-              ),
+              getDayContainer(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay, textStyle, defaultTextStyle, isNextMonthDay, isThisMonthDay, now),
               widget.markedDatesMap != null
                   ? _renderMarkedMapContainer(now)
                   : Container(),

--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -315,6 +315,7 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
               : defaultTextStyle,
         child: Text(
           '${now.day}',
+          semanticsLabel: now.day.toString(),
           style:
             isSelectedDay && widget.selectedDayTextStyle != null
             ? widget.selectedDayTextStyle
@@ -843,6 +844,9 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
                   child: Center(
                     child: Text(
                       widget.markedDateMoreShowTotal
+                        ? (count + widget.markedDateIconMaxShown).toString()
+                        : (count.toString() + '+'),
+                      semanticsLabel: widget.markedDateMoreShowTotal
                         ? (count + widget.markedDateIconMaxShown).toString()
                         : (count.toString() + '+'),
                       style: widget.markedDateMoreCustomTextStyle == null

--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -40,7 +40,7 @@ class CalendarCarousel<T> extends StatefulWidget {
   final TextStyle weekdayTextStyle;
   final Color iconColor;
   final TextStyle headerTextStyle;
-  final Widget headerText;
+  final String headerText;
   final TextStyle weekendTextStyle;
   final EventList<Event> markedDatesMap;
   /// Change `makredDateWidget` when `markedDateShowIcon` is set to false.
@@ -244,9 +244,11 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
           CalendarHeader(
             showHeader: widget.showHeader,
             headerMargin: widget.headerMargin,
-            headerTitle: widget.weekFormat
-                ? '${_localeDate.format(_weeks[1].first)}'
-                : '${_localeDate.format(this._dates[1])}',
+            headerTitle: widget.headerText != null
+                ? widget.headerText
+                : widget.weekFormat
+                  ? '${_localeDate.format(_weeks[1].first)}'
+                  : '${_localeDate.format(this._dates[1])}',
             headerTextStyle: widget.headerTextStyle,
             showHeaderButtons: widget.showHeaderButton,
             headerIconColor: widget.iconColor,

--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 
 import 'package:date_utils/date_utils.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_calendar_carousel/classes/event.dart';
 import 'package:flutter_calendar_carousel/classes/event_list.dart';
 import 'package:flutter_calendar_carousel/src/default_styles.dart';
 import 'package:flutter_calendar_carousel/src/calendar_header.dart';
@@ -12,7 +13,7 @@ import 'package:intl/date_symbol_data_local.dart';
 import 'package:intl/intl.dart' show DateFormat;
 export 'package:flutter_calendar_carousel/classes/event_list.dart';
 
-typedef MarkedDateIconBuilder<T> = Widget Function(T event);
+typedef MarkedDateIconBuilder<Event> = Widget Function(Event event);
 
 class CalendarCarousel<T> extends StatefulWidget {
   final double viewportFraction;
@@ -40,7 +41,7 @@ class CalendarCarousel<T> extends StatefulWidget {
   final TextStyle headerTextStyle;
   final Widget headerText;
   final TextStyle weekendTextStyle;
-  final EventList<T> markedDatesMap;
+  final EventList<Event> markedDatesMap;
   /// Change `makredDateWidget` when `markedDateShowIcon` is set to false.
   final Widget markedDateWidget;
   /// Change `ShapeBorder` when `markedDateShowIcon` is set to false.
@@ -55,7 +56,7 @@ class CalendarCarousel<T> extends StatefulWidget {
   final int markedDateIconMaxShown;
   final double markedDateIconMargin;
   final double markedDateIconOffset;
-  final MarkedDateIconBuilder<T> markedDateIconBuilder;
+  final MarkedDateIconBuilder<Event> markedDateIconBuilder;
   /// null - no indicator, true - show the total events, false - show the total of hidden events
   final bool markedDateMoreShowTotal;
   final Decoration markedDateMoreCustomDecoration;
@@ -841,7 +842,7 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
       int eventIndex = 0;
       double offset = 0.0;
       double padding = widget.markedDateIconMargin;
-      widget.markedDatesMap.getEvents(now).forEach((event) {
+      widget.markedDatesMap.getEvents(now).forEach((Event event) {
         if (widget.markedDateShowIcon) {
           if (tmp.length > 0 && tmp.length < widget.markedDateIconMaxShown) {
             offset += widget.markedDateIconOffset;
@@ -902,7 +903,10 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
             if (widget.markedDateIconBuilder != null) {
               tmp.add(widget.markedDateIconBuilder(event));
             } else {
-              if (widget.markedDateWidget != null) {
+              if (event.dot != null) {
+                tmp.add(event.dot);
+              }
+              else if (widget.markedDateWidget != null) {
                 tmp.add(widget.markedDateWidget);
               } else {
                 tmp.add(defaultMarkedDateWidget);

--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -14,6 +14,7 @@ import 'package:intl/intl.dart' show DateFormat;
 export 'package:flutter_calendar_carousel/classes/event_list.dart';
 
 typedef MarkedDateIconBuilder<Event> = Widget Function(Event event);
+typedef void OnDayLongPressed(DateTime day);
 
 class CalendarCarousel<T> extends StatefulWidget {
   final double viewportFraction;
@@ -88,6 +89,7 @@ class CalendarCarousel<T> extends StatefulWidget {
   final bool isScrollable;
   final bool showOnlyCurrentMonthDate;
   final bool pageSnapping;
+  final OnDayLongPressed onDayLongPressed;
 
   CalendarCarousel({
     this.viewportFraction = 1.0,
@@ -155,6 +157,7 @@ class CalendarCarousel<T> extends StatefulWidget {
     this.isScrollable = true,
     this.showOnlyCurrentMonthDate = false,
     this.pageSnapping = false,
+    this.onDayLongPressed,
   });
 
   @override
@@ -351,57 +354,60 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
   ) {
     return Container(
       margin: EdgeInsets.all(widget.dayPadding),
-      child: FlatButton(
-        color:
-            isSelectedDay && widget.selectedDayButtonColor != null
-                ? widget.selectedDayButtonColor
-                : isToday && widget.todayButtonColor != null
-                    ? widget.todayButtonColor
-                    : widget.dayButtonColor,
-        onPressed: () => _onDayPressed(now),
-        padding: EdgeInsets.all(widget.dayPadding),
-        shape: widget.markedDateCustomShapeBorder != null
-          && widget.markedDatesMap != null
-          && widget.markedDatesMap.getEvents(now).length > 0
-          ? widget.markedDateCustomShapeBorder
-          : widget.daysHaveCircularBorder == null
-            ? CircleBorder()
-            : widget.daysHaveCircularBorder ?? false
-              ? CircleBorder(
-                  side: BorderSide(
-                    color: isSelectedDay
-                      ? widget.selectedDayBorderColor
-                      : isToday && widget.todayBorderColor != null
-                        ? widget.todayBorderColor
-                        : isPrevMonthDay
-                          ? widget.prevMonthDayBorderColor
-                          : isNextMonthDay
-                            ? widget.nextMonthDayBorderColor
-                            : widget.thisMonthDayBorderColor,
-                  ),
-                )
-              : RoundedRectangleBorder(
-                  side: BorderSide(
-                    color: isSelectedDay
+      child: GestureDetector(
+        onLongPress: () => _onDayLongPressed(now),
+        child: FlatButton(
+          color:
+              isSelectedDay && widget.selectedDayButtonColor != null
+                  ? widget.selectedDayButtonColor
+                  : isToday && widget.todayButtonColor != null
+                      ? widget.todayButtonColor
+                      : widget.dayButtonColor,
+          onPressed: () => _onDayPressed(now),
+          padding: EdgeInsets.all(widget.dayPadding),
+          shape: widget.markedDateCustomShapeBorder != null
+            && widget.markedDatesMap != null
+            && widget.markedDatesMap.getEvents(now).length > 0
+            ? widget.markedDateCustomShapeBorder
+            : widget.daysHaveCircularBorder == null
+              ? CircleBorder()
+              : widget.daysHaveCircularBorder ?? false
+                ? CircleBorder(
+                    side: BorderSide(
+                      color: isSelectedDay
                         ? widget.selectedDayBorderColor
                         : isToday && widget.todayBorderColor != null
-                            ? widget.todayBorderColor
-                            : isPrevMonthDay
-                                ? widget.prevMonthDayBorderColor
-                                : isNextMonthDay
-                                    ? widget.nextMonthDayBorderColor
-                                    : widget.thisMonthDayBorderColor,
+                          ? widget.todayBorderColor
+                          : isPrevMonthDay
+                            ? widget.prevMonthDayBorderColor
+                            : isNextMonthDay
+                              ? widget.nextMonthDayBorderColor
+                              : widget.thisMonthDayBorderColor,
+                    ),
+                  )
+                : RoundedRectangleBorder(
+                    side: BorderSide(
+                      color: isSelectedDay
+                          ? widget.selectedDayBorderColor
+                          : isToday && widget.todayBorderColor != null
+                              ? widget.todayBorderColor
+                              : isPrevMonthDay
+                                  ? widget.prevMonthDayBorderColor
+                                  : isNextMonthDay
+                                      ? widget.nextMonthDayBorderColor
+                                      : widget.thisMonthDayBorderColor,
+                    ),
                   ),
-                ),
-        child: Stack(
-          children: <Widget>[
-            Center(
-              child: getDefaultTextStyle(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay, textStyle, defaultTextStyle, isNextMonthDay, isThisMonthDay, now),
-            ),
-            widget.markedDatesMap != null
-                ? _renderMarkedMapContainer(now)
-                : Container(),
-          ],
+          child: Stack(
+            children: <Widget>[
+              Center(
+                child: getDefaultTextStyle(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay, textStyle, defaultTextStyle, isNextMonthDay, isThisMonthDay, now),
+              ),
+              widget.markedDatesMap != null
+                  ? _renderMarkedMapContainer(now)
+                  : Container(),
+            ],
+          ),
         ),
       ),
     );
@@ -612,6 +618,10 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
 
     return Utils.daysInRange(firstDayOfCurrentWeek, lastDayOfCurrentWeek)
         .toList();
+  }
+
+  void _onDayLongPressed(DateTime picked) {
+    widget.onDayLongPressed(picked);
   }
 
   void _onDayPressed(DateTime picked) {

--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -92,6 +92,7 @@ class CalendarCarousel<T> extends StatefulWidget {
   final OnDayLongPressed onDayLongPressed;
   final CrossAxisAlignment dayCrossAxisAlignment;
   final MainAxisAlignment dayMainAxisAlignment;
+  final bool showIconBehindDayText;
 
   CalendarCarousel({
     this.viewportFraction = 1.0,
@@ -162,6 +163,7 @@ class CalendarCarousel<T> extends StatefulWidget {
     this.onDayLongPressed,
     this.dayCrossAxisAlignment = CrossAxisAlignment.center,
     this.dayMainAxisAlignment = MainAxisAlignment.center,
+    this.showIconBehindDayText = false,
   });
 
   @override
@@ -414,12 +416,19 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
                     ),
                   ),
           child: Stack(
-            children: <Widget>[
-              getDayContainer(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay, textStyle, defaultTextStyle, isNextMonthDay, isThisMonthDay, now),
-              widget.markedDatesMap != null
-                  ? _renderMarkedMapContainer(now)
-                  : Container(),
-            ],
+            children: widget.showIconBehindDayText
+              ? <Widget>[
+                widget.markedDatesMap != null
+                    ? _renderMarkedMapContainer(now)
+                    : Container(),
+                getDayContainer(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay, textStyle, defaultTextStyle, isNextMonthDay, isThisMonthDay, now),
+              ]
+              : <Widget>[
+                getDayContainer(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay, textStyle, defaultTextStyle, isNextMonthDay, isThisMonthDay, now),
+                widget.markedDatesMap != null
+                    ? _renderMarkedMapContainer(now)
+                    : Container(),
+              ],
           ),
         ),
       ),

--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -51,6 +51,8 @@ class CalendarCarousel<T> extends StatefulWidget {
   final bool
       markedDateMoreShowTotal; // null - no indicator, true - show the total events, false - show the total of hidden events
   final Decoration markedDateMoreCustomDecoration;
+  final ShapeBorder markedDateCustomShapeBorder;
+  final TextStyle markedDateCustomTextStyle;
   final TextStyle markedDateMoreCustomTextStyle;
   final EdgeInsets headerMargin;
   final double childAspectRatio;
@@ -115,6 +117,8 @@ class CalendarCarousel<T> extends StatefulWidget {
     this.markedDateIconBuilder,
     this.markedDateMoreShowTotal,
     this.markedDateMoreCustomDecoration,
+    this.markedDateCustomShapeBorder,
+    this.markedDateCustomTextStyle,
     this.markedDateMoreCustomTextStyle,
     this.markedDateWidget,
     this.headerMargin = const EdgeInsets.symmetric(vertical: 16.0),
@@ -355,6 +359,11 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
                   } else {
                     return Container();
                   }
+                  if (widget.markedDateCustomTextStyle != null
+                    && widget.markedDatesMap != null
+                    && widget.markedDatesMap.getEvents(now).length > 0) {
+                    textStyle = widget.markedDateCustomTextStyle;
+                  }
                   bool isSelectable = true;
                   if (widget.minSelectedDate != null &&
                       now.millisecondsSinceEpoch <
@@ -375,87 +384,80 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
                                   : widget.dayButtonColor,
                       onPressed: () => _onDayPressed(now),
                       padding: EdgeInsets.all(widget.dayPadding),
-                      shape: widget.daysHaveCircularBorder == null
+                      shape: widget.markedDateCustomShapeBorder != null
+                        && widget.markedDatesMap != null
+                        && widget.markedDatesMap.getEvents(now).length > 0
+                        ? widget.markedDateCustomShapeBorder
+                        : widget.daysHaveCircularBorder == null
                           ? CircleBorder()
-                          : widget.daysHaveCircularBorder
-                              ? CircleBorder(
-                                  side: BorderSide(
-                                    color: isSelectedDay
-                                        ? widget.selectedDayBorderColor
-                                        : isToday && widget.todayBorderColor != null
-                                            ? widget.todayBorderColor
-                                            : isPrevMonthDay
-                                                ? widget.prevMonthDayBorderColor
-                                                : isNextMonthDay
-                                                    ? widget
-                                                        .nextMonthDayBorderColor
-                                                    : widget
-                                                        .thisMonthDayBorderColor,
-                                  ),
-                                )
-                              : RoundedRectangleBorder(
-                                  side: BorderSide(
-                                    color: isSelectedDay
-                                        ? widget.selectedDayBorderColor
-                                        : isToday && widget.todayBorderColor != null
-                                            ? widget.todayBorderColor
-                                            : isPrevMonthDay
-                                                ? widget.prevMonthDayBorderColor
-                                                : isNextMonthDay
-                                                    ? widget
-                                                        .nextMonthDayBorderColor
-                                                    : widget
-                                                        .thisMonthDayBorderColor,
-                                  ),
+                          : widget.daysHaveCircularBorder ?? false
+                            ? CircleBorder(
+                                side: BorderSide(
+                                  color: isSelectedDay
+                                    ? widget.selectedDayBorderColor
+                                    : isToday && widget.todayBorderColor != null
+                                      ? widget.todayBorderColor
+                                      : isPrevMonthDay
+                                        ? widget.prevMonthDayBorderColor
+                                        : isNextMonthDay
+                                          ? widget.nextMonthDayBorderColor
+                                          : widget.thisMonthDayBorderColor,
                                 ),
+                              )
+                            : RoundedRectangleBorder(
+                                side: BorderSide(
+                                  color: isSelectedDay
+                                      ? widget.selectedDayBorderColor
+                                      : isToday && widget.todayBorderColor != null
+                                          ? widget.todayBorderColor
+                                          : isPrevMonthDay
+                                              ? widget.prevMonthDayBorderColor
+                                              : isNextMonthDay
+                                                  ? widget.nextMonthDayBorderColor
+                                                  : widget.thisMonthDayBorderColor,
+                                ),
+                              ),
                       child: Stack(
                         children: <Widget>[
                           Center(
                             child: DefaultTextStyle(
-                              style: (_localeDate.dateSymbols.WEEKENDRANGE
-                                          .contains(
-                                              (index - 1 + firstDayOfWeek) %
-                                                  7)) &&
-                                      !isSelectedDay &&
-                                      !isToday
-                                  ? (isPrevMonthDay
-                                      ? defaultPrevDaysTextStyle
-                                      : isNextMonthDay
-                                          ? defaultNextDaysTextStyle
-                                          : isSelectable
-                                              ? defaultWeekendTextStyle
-                                              : defaultInactiveWeekendTextStyle)
-                                  : isToday
-                                      ? defaultTodayTextStyle
-                                      : isSelectable && textStyle != null
-                                          ? textStyle
-                                          : defaultTextStyle != null
-                                            ? defaultTextStyle
-                                            : defaultInactiveDaysTextStyle,
+                              style: (_localeDate.dateSymbols.WEEKENDRANGE.contains(
+                                  (index - 1 + firstDayOfWeek) % 7)) && !isSelectedDay && !isToday
+                                ? (isPrevMonthDay
+                                  ? defaultPrevDaysTextStyle
+                                  : isNextMonthDay
+                                    ? defaultNextDaysTextStyle
+                                    : isSelectable
+                                      ? defaultWeekendTextStyle
+                                      : defaultInactiveWeekendTextStyle)
+                                : isToday
+                                  ? defaultTodayTextStyle
+                                  : isSelectable && textStyle != null
+                                      ? textStyle
+                                      : defaultTextStyle != null
+                                        ? defaultTextStyle
+                                        : defaultInactiveDaysTextStyle,
                               child: Text(
                                 '${now.day}',
-                                style: (_localeDate.dateSymbols.WEEKENDRANGE
-                                            .contains(
-                                                (index - 1 + firstDayOfWeek) %
-                                                    7)) &&
-                                        !isSelectedDay &&
-                                        isThisMonthDay &&
-                                        !isToday
-                                    ? (isSelectable
-                                        ? widget.weekendTextStyle
-                                        : widget.inactiveWeekendTextStyle)
-                                    : isPrevMonthDay
-                                        ? widget.prevDaysTextStyle
-                                        : isNextMonthDay
-                                            ? widget.nextDaysTextStyle
-                                            : isSelectedDay
-                                                ? widget.selectedDayTextStyle
-                                                : isToday
-                                                    ? widget.todayTextStyle
-                                                    : isSelectable
-                                                        ? widget.daysTextStyle
-                                                        : widget
-                                                            .inactiveDaysTextStyle,
+                                style: (_localeDate.dateSymbols.WEEKENDRANGE.contains(
+                                  (index - 1 + firstDayOfWeek) % 7))
+                                  && !isSelectedDay
+                                  && isThisMonthDay
+                                  && !isToday
+                                  ? (isSelectable
+                                      ? widget.weekendTextStyle
+                                      : widget.inactiveWeekendTextStyle)
+                                  : isPrevMonthDay
+                                      ? widget.prevDaysTextStyle
+                                      : isNextMonthDay
+                                        ? widget.nextDaysTextStyle
+                                        : isSelectedDay
+                                            ? widget.selectedDayTextStyle
+                                            : isToday
+                                                ? widget.todayTextStyle
+                                                : isSelectable
+                                                  ? widget.daysTextStyle
+                                                  : widget.inactiveDaysTextStyle,
                                 maxLines: 1,
                               ),
                             ),
@@ -508,10 +510,7 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
                   crossAxisCount: 7,
                   childAspectRatio: widget.childAspectRatio,
                   padding: EdgeInsets.zero,
-                  children: List.generate(weekDays.length,
-
-                      /// last day of month + weekday
-                      (index) {
+                  children: List.generate(weekDays.length, (index) { /// last day of month + weekday
                     bool isToday = weekDays[index].day == DateTime.now().day &&
                         weekDays[index].month == DateTime.now().month &&
                         weekDays[index].year == DateTime.now().year;
@@ -534,15 +533,15 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
                       defaultTextStyle = defaultPrevDaysTextStyle;
                     } else if (isThisMonthDay) {
                       textStyle = isSelectedDay
-                          ? widget.selectedDayTextStyle
-                          : isToday
-                              ? widget.todayTextStyle
-                              : widget.daysTextStyle;
+                        ? widget.selectedDayTextStyle
+                        : isToday
+                          ? widget.todayTextStyle
+                          : widget.daysTextStyle;
                       defaultTextStyle = isSelectedDay
-                          ? defaultSelectedDayTextStyle
-                          : isToday
-                              ? defaultTodayTextStyle
-                              : defaultDaysTextStyle;
+                        ? defaultSelectedDayTextStyle
+                        : isToday
+                          ? defaultTodayTextStyle
+                          : defaultDaysTextStyle;
                     } else if (!widget.showOnlyCurrentMonthDate) {
                       textStyle = widget.nextDaysTextStyle;
                       defaultTextStyle = defaultNextDaysTextStyle;
@@ -561,88 +560,81 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
                     return Container(
                       margin: EdgeInsets.all(widget.dayPadding),
                       child: FlatButton(
-                        color: isSelectedDay &&
-                                widget.selectedDayButtonColor != null
-                            ? widget.selectedDayButtonColor
-                            : isToday && widget.todayButtonColor != null
-                                ? widget.todayButtonColor
-                                : widget.dayButtonColor,
+                        color: isSelectedDay && widget.selectedDayButtonColor != null
+                          ? widget.selectedDayButtonColor
+                          : isToday && widget.todayButtonColor != null
+                              ? widget.todayButtonColor
+                              : widget.dayButtonColor,
                         onPressed: () => _onDayPressed(now),
                         padding: EdgeInsets.all(widget.dayPadding),
-                        shape: widget.daysHaveCircularBorder == null
+                        shape: widget.markedDateCustomShapeBorder != null
+                          && widget.markedDatesMap != null
+                          && widget.markedDatesMap.getEvents(now).length > 0
+                          ? widget.markedDateCustomShapeBorder
+                          : widget.daysHaveCircularBorder == null
                             ? CircleBorder()
-                            : widget.daysHaveCircularBorder
-                                ? CircleBorder(
-                                    side: BorderSide(
-                                      color: isSelectedDay
-                                          ? widget.selectedDayBorderColor
-                                          : isToday &&
-                                                  widget.todayBorderColor !=
-                                                      null
-                                              ? widget.todayBorderColor
-                                              : isPrevMonthDay
-                                                  ? widget
-                                                      .prevMonthDayBorderColor
-                                                  : isNextMonthDay
-                                                      ? widget
-                                                          .nextMonthDayBorderColor
-                                                      : widget
-                                                          .thisMonthDayBorderColor,
-                                    ),
-                                  )
-                                : RoundedRectangleBorder(
-                                    side: BorderSide(
-                                      color: isSelectedDay
-                                          ? widget.selectedDayBorderColor
-                                          : isToday &&
-                                                  widget.todayBorderColor !=
-                                                      null
-                                              ? widget.todayBorderColor
-                                              : isPrevMonthDay
-                                                  ? widget
-                                                      .prevMonthDayBorderColor
-                                                  : isNextMonthDay
-                                                      ? widget
-                                                          .nextMonthDayBorderColor
-                                                      : widget
-                                                          .thisMonthDayBorderColor,
-                                    ),
+                            : widget.daysHaveCircularBorder?? false
+                              ? CircleBorder(
+                                  side: BorderSide(
+                                    color: isSelectedDay
+                                      ? widget.selectedDayBorderColor
+                                      : isToday && widget.todayBorderColor != null
+                                          ? widget.todayBorderColor
+                                          : isPrevMonthDay
+                                            ? widget.prevMonthDayBorderColor
+                                            : isNextMonthDay
+                                                ? widget.nextMonthDayBorderColor
+                                                : widget.thisMonthDayBorderColor,
                                   ),
+                                )
+                              : RoundedRectangleBorder(
+                                  side: BorderSide(
+                                    color: isSelectedDay
+                                        ? widget.selectedDayBorderColor
+                                        : isToday && widget.todayBorderColor != null
+                                          ? widget.todayBorderColor
+                                          : isPrevMonthDay
+                                            ? widget.prevMonthDayBorderColor
+                                            : isNextMonthDay
+                                                ? widget.nextMonthDayBorderColor
+                                                : widget.thisMonthDayBorderColor,
+                                  ),
+                                ),
                         child: Stack(
                           children: <Widget>[
                             Center(
                               child: DefaultTextStyle(
                                 style: (index % 7 == 0 || index % 7 == 6) &&
-                                        !isSelectedDay &&
-                                        !isToday &&
-                                        !isPrevMonthDay &&
-                                        !isNextMonthDay
+                                      !isSelectedDay &&
+                                      !isToday &&
+                                      !isPrevMonthDay &&
+                                      !isNextMonthDay
                                     ? (isSelectable
-                                        ? defaultWeekendTextStyle
-                                        : defaultInactiveWeekendTextStyle)
+                                      ? defaultWeekendTextStyle
+                                      : defaultInactiveWeekendTextStyle)
                                     : isToday
-                                        ? defaultTodayTextStyle
-                                        : textStyle != null
-                                          ? textStyle
-                                          : defaultTextStyle,
+                                      ? defaultTodayTextStyle
+                                      : textStyle != null
+                                        ? textStyle
+                                        : defaultTextStyle,
                                 child: Text(
                                   '${now.day}',
                                   style: (index % 7 == 0 || index % 7 == 6) &&
-                                          !isSelectedDay &&
-                                          !isToday
-                                      ? widget.weekendTextStyle
-                                      : isToday
-                                          ? widget.todayTextStyle
-                                          : isSelectable
-                                              ? textStyle
-                                              : widget.inactiveDaysTextStyle,
+                                    !isSelectedDay &&
+                                    !isToday
+                                    ? widget.weekendTextStyle
+                                    : isToday
+                                      ? widget.todayTextStyle
+                                      : isSelectable
+                                        ? textStyle
+                                        : widget.inactiveDaysTextStyle,
                                   maxLines: 1,
                                 ),
                               ),
                             ),
                             widget.markedDatesMap != null
-                                ? _renderMarkedMapContainer(now)
-                                : Container(),
+                              ? _renderMarkedMapContainer(now)
+                              : Container(),
                           ],
                         ),
                       ),
@@ -680,10 +672,10 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
     });
     if (widget.onDayPressed != null)
       widget.onDayPressed(
-          picked,
-          widget.markedDatesMap != null
-              ? widget.markedDatesMap.getEvents(picked)
-              : []);
+        picked,
+        widget.markedDatesMap != null
+          ? widget.markedDatesMap.getEvents(picked)
+          : []);
     _setDate();
   }
 
@@ -692,11 +684,11 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
       context: context,
       initialDate: _selectedDate ?? new DateTime.now(),
       firstDate: widget.minSelectedDate != null
-          ? widget.minSelectedDate
-          : DateTime(1960),
+        ? widget.minSelectedDate
+        : DateTime(1960),
       lastDate: widget.maxSelectedDate != null
-          ? widget.maxSelectedDate
-          : DateTime(2050),
+        ? widget.maxSelectedDate
+        : DateTime(2050),
     );
 
     if (selected != null) {
@@ -707,10 +699,10 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
       });
       if (widget.onDayPressed != null)
         widget.onDayPressed(
-            selected,
-            widget.markedDatesMap != null
-                ? widget.markedDatesMap.getEvents(selected)
-                : []);
+          selected,
+          widget.markedDatesMap != null
+            ? widget.markedDatesMap.getEvents(selected)
+            : []);
       _setDate();
     }
   }
@@ -718,11 +710,11 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
   void _setDatesAndWeeks() {
     /// Setup default calendar format
     DateTime date0 =
-        DateTime(this._selectedDate.year, this._selectedDate.month - 1, 1);
+      DateTime(this._selectedDate.year, this._selectedDate.month - 1, 1);
     DateTime date1 =
-        DateTime(this._selectedDate.year, this._selectedDate.month, 1);
+      DateTime(this._selectedDate.year, this._selectedDate.month, 1);
     DateTime date2 =
-        DateTime(this._selectedDate.year, this._selectedDate.month + 1, 1);
+      DateTime(this._selectedDate.year, this._selectedDate.month + 1, 1);
 
     /// Setup week-only format
     DateTime now = this._selectedDate;
@@ -761,19 +753,15 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
         List<List<DateTime>> newWeeks = this._weeks;
         if (page == 0) {
           curr = _weeks[0].first;
-          newWeeks[0] =
-              _getDaysInWeek(DateTime(curr.year, curr.month, curr.day - 7));
+          newWeeks[0] = _getDaysInWeek(DateTime(curr.year, curr.month, curr.day - 7));
           newWeeks[1] = _getDaysInWeek(curr);
-          newWeeks[2] =
-              _getDaysInWeek(DateTime(curr.year, curr.month, curr.day + 7));
+          newWeeks[2] = _getDaysInWeek(DateTime(curr.year, curr.month, curr.day + 7));
           page += 1;
         } else if (page == 2) {
           curr = _weeks[2].first;
           newWeeks[1] = _getDaysInWeek(curr);
-          newWeeks[0] =
-              _getDaysInWeek(DateTime(curr.year, curr.month, curr.day - 7));
-          newWeeks[2] =
-              _getDaysInWeek(DateTime(curr.year, curr.month, curr.day + 7));
+          newWeeks[0] = _getDaysInWeek(DateTime(curr.year, curr.month, curr.day - 7));
+          newWeeks[2] = _getDaysInWeek(DateTime(curr.year, curr.month, curr.day + 7));
           page -= 1;
         }
         setState(() {
@@ -814,8 +802,8 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         _isReloadSelectedDate = false;
         widget.onCalendarChanged(!widget.weekFormat
-            ? this._dates[1]
-            : this._weeks[1][firstDayOfWeek]);
+          ? this._dates[1]
+          : this._weeks[1][firstDayOfWeek]);
       });
     }
   }
@@ -875,25 +863,27 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
                 bottom: 0.0,
                 right: 0.0,
                 child: Container(
-                  padding: EdgeInsets.all(3.0),
+                  padding: EdgeInsets.all(4.0),
+                  width: widget.markedDateMoreShowTotal ? 18 : null,
+                  height: widget.markedDateMoreShowTotal ? 18 : null,
                   decoration: widget.markedDateMoreCustomDecoration == null
-                      ? new BoxDecoration(
-                          color: Colors.red,
-                          borderRadius:
-                              BorderRadius.all(Radius.circular(1000.0)),
-                        )
-                      : widget.markedDateMoreCustomDecoration,
+                    ? new BoxDecoration(
+                        color: Colors.red,
+                        borderRadius:
+                            BorderRadius.all(Radius.circular(1000.0)),
+                      )
+                    : widget.markedDateMoreCustomDecoration,
                   child: Center(
                     child: Text(
                       widget.markedDateMoreShowTotal
-                          ? (count + widget.markedDateIconMaxShown).toString()
-                          : (count.toString() + '+'),
+                        ? (count + widget.markedDateIconMaxShown).toString()
+                        : (count.toString() + '+'),
                       style: widget.markedDateMoreCustomTextStyle == null
-                          ? TextStyle(
-                              fontSize: 9.0,
-                              color: Colors.white,
-                              fontWeight: FontWeight.normal)
-                          : widget.markedDateMoreCustomTextStyle,
+                        ? TextStyle(
+                            fontSize: 9.0,
+                            color: Colors.white,
+                            fontWeight: FontWeight.normal)
+                        : widget.markedDateMoreCustomTextStyle,
                     ),
                   ),
                 ),

--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -281,6 +281,132 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
     );
   }
 
+  DefaultTextStyle getDefaultTextStyle(
+    bool isSelectable,
+    int index,
+    bool isSelectedDay,
+    bool isToday,
+    bool isPrevMonthDay,
+    TextStyle textStyle,
+    TextStyle defaultTextStyle,
+    bool isNextMonthDay,
+    bool isThisMonthDay,
+    DateTime now,
+  ) {
+    return DefaultTextStyle(
+      style: !isSelectable
+      ?  defaultInactiveDaysTextStyle
+      : (_localeDate.dateSymbols.WEEKENDRANGE.contains(
+          (index - 1 + firstDayOfWeek) % 7)) && !isSelectedDay && !isToday
+        ? (isPrevMonthDay
+          ? defaultPrevDaysTextStyle
+          : isNextMonthDay
+            ? defaultNextDaysTextStyle
+            : isSelectable
+              ? defaultWeekendTextStyle
+              : defaultInactiveWeekendTextStyle)
+        : isToday
+          ? defaultTodayTextStyle
+          : isSelectable && textStyle != null
+              ? textStyle
+              : defaultTextStyle,
+        child: Text(
+          '${now.day}',
+          style:
+            isSelectedDay && widget.selectedDayTextStyle != null
+            ? widget.selectedDayTextStyle
+            : (_localeDate.dateSymbols.WEEKENDRANGE.contains(
+            (index - 1 + firstDayOfWeek) % 7))
+            && !isSelectedDay
+            && isThisMonthDay
+            && !isToday
+            ? (isSelectable
+                ? widget.weekendTextStyle
+                : widget.inactiveWeekendTextStyle)
+            : !isSelectable
+            ? widget.inactiveDaysTextStyle
+            : isPrevMonthDay
+                ? widget.prevDaysTextStyle
+                : isNextMonthDay
+                  ? widget.nextDaysTextStyle
+                  : isToday
+                      ? widget.todayTextStyle
+                      : widget.daysTextStyle,
+          maxLines: 1,
+        ),
+    );
+  }
+
+  Widget renderDay(
+    bool isSelectable,
+    int index,
+    bool isSelectedDay,
+    bool isToday,
+    bool isPrevMonthDay,
+    TextStyle textStyle,
+    TextStyle defaultTextStyle,
+    bool isNextMonthDay,
+    bool isThisMonthDay,
+    DateTime now,
+  ) {
+    return Container(
+      margin: EdgeInsets.all(widget.dayPadding),
+      child: FlatButton(
+        color:
+            isSelectedDay && widget.selectedDayButtonColor != null
+                ? widget.selectedDayButtonColor
+                : isToday && widget.todayButtonColor != null
+                    ? widget.todayButtonColor
+                    : widget.dayButtonColor,
+        onPressed: () => _onDayPressed(now),
+        padding: EdgeInsets.all(widget.dayPadding),
+        shape: widget.markedDateCustomShapeBorder != null
+          && widget.markedDatesMap != null
+          && widget.markedDatesMap.getEvents(now).length > 0
+          ? widget.markedDateCustomShapeBorder
+          : widget.daysHaveCircularBorder == null
+            ? CircleBorder()
+            : widget.daysHaveCircularBorder ?? false
+              ? CircleBorder(
+                  side: BorderSide(
+                    color: isSelectedDay
+                      ? widget.selectedDayBorderColor
+                      : isToday && widget.todayBorderColor != null
+                        ? widget.todayBorderColor
+                        : isPrevMonthDay
+                          ? widget.prevMonthDayBorderColor
+                          : isNextMonthDay
+                            ? widget.nextMonthDayBorderColor
+                            : widget.thisMonthDayBorderColor,
+                  ),
+                )
+              : RoundedRectangleBorder(
+                  side: BorderSide(
+                    color: isSelectedDay
+                        ? widget.selectedDayBorderColor
+                        : isToday && widget.todayBorderColor != null
+                            ? widget.todayBorderColor
+                            : isPrevMonthDay
+                                ? widget.prevMonthDayBorderColor
+                                : isNextMonthDay
+                                    ? widget.nextMonthDayBorderColor
+                                    : widget.thisMonthDayBorderColor,
+                  ),
+                ),
+        child: Stack(
+          children: <Widget>[
+            Center(
+              child: getDefaultTextStyle(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay, textStyle, defaultTextStyle, isNextMonthDay, isThisMonthDay, now),
+            ),
+            widget.markedDatesMap != null
+                ? _renderMarkedMapContainer(now)
+                : Container(),
+          ],
+        ),
+      ),
+    );
+  }
+
   AnimatedBuilder builder(int slideIndex) {
     double screenWidth = MediaQuery.of(context).size.width;
     int totalItemCount = widget.staticSixWeekFormat
@@ -380,102 +506,7 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
                       now.millisecondsSinceEpoch >
                           widget.maxSelectedDate.millisecondsSinceEpoch)
                     isSelectable = false;
-                  return Container(
-                    margin: EdgeInsets.all(widget.dayPadding),
-                    child: FlatButton(
-                      color:
-                          isSelectedDay && widget.selectedDayButtonColor != null
-                              ? widget.selectedDayButtonColor
-                              : isToday && widget.todayButtonColor != null
-                                  ? widget.todayButtonColor
-                                  : widget.dayButtonColor,
-                      onPressed: () => _onDayPressed(now),
-                      padding: EdgeInsets.all(widget.dayPadding),
-                      shape: widget.markedDateCustomShapeBorder != null
-                        && widget.markedDatesMap != null
-                        && widget.markedDatesMap.getEvents(now).length > 0
-                        ? widget.markedDateCustomShapeBorder
-                        : widget.daysHaveCircularBorder == null
-                          ? CircleBorder()
-                          : widget.daysHaveCircularBorder ?? false
-                            ? CircleBorder(
-                                side: BorderSide(
-                                  color: isSelectedDay
-                                    ? widget.selectedDayBorderColor
-                                    : isToday && widget.todayBorderColor != null
-                                      ? widget.todayBorderColor
-                                      : isPrevMonthDay
-                                        ? widget.prevMonthDayBorderColor
-                                        : isNextMonthDay
-                                          ? widget.nextMonthDayBorderColor
-                                          : widget.thisMonthDayBorderColor,
-                                ),
-                              )
-                            : RoundedRectangleBorder(
-                                side: BorderSide(
-                                  color: isSelectedDay
-                                      ? widget.selectedDayBorderColor
-                                      : isToday && widget.todayBorderColor != null
-                                          ? widget.todayBorderColor
-                                          : isPrevMonthDay
-                                              ? widget.prevMonthDayBorderColor
-                                              : isNextMonthDay
-                                                  ? widget.nextMonthDayBorderColor
-                                                  : widget.thisMonthDayBorderColor,
-                                ),
-                              ),
-                      child: Stack(
-                        children: <Widget>[
-                          Center(
-                            child: DefaultTextStyle(
-                              style: !isSelectable
-                              ?  defaultInactiveDaysTextStyle
-                              : (_localeDate.dateSymbols.WEEKENDRANGE.contains(
-                                  (index - 1 + firstDayOfWeek) % 7)) && !isSelectedDay && !isToday
-                                ? (isPrevMonthDay
-                                  ? defaultPrevDaysTextStyle
-                                  : isNextMonthDay
-                                    ? defaultNextDaysTextStyle
-                                    : isSelectable
-                                      ? defaultWeekendTextStyle
-                                      : defaultInactiveWeekendTextStyle)
-                                : isToday
-                                  ? defaultTodayTextStyle
-                                  : isSelectable && textStyle != null
-                                      ? textStyle
-                                      : defaultTextStyle,
-                                child: Text(
-                                  '${now.day}',
-                                  style: (_localeDate.dateSymbols.WEEKENDRANGE.contains(
-                                    (index - 1 + firstDayOfWeek) % 7))
-                                    && !isSelectedDay
-                                    && isThisMonthDay
-                                    && !isToday
-                                    ? (isSelectable
-                                        ? widget.weekendTextStyle
-                                        : widget.inactiveWeekendTextStyle)
-                                    : !isSelectable
-                                    ? widget.inactiveDaysTextStyle
-                                    : isPrevMonthDay
-                                        ? widget.prevDaysTextStyle
-                                        : isNextMonthDay
-                                          ? widget.nextDaysTextStyle
-                                          : isSelectedDay
-                                              ? widget.selectedDayTextStyle
-                                              : isToday
-                                                  ? widget.todayTextStyle
-                                                  : widget.daysTextStyle,
-                                  maxLines: 1,
-                                ),
-                            ),
-                          ),
-                          widget.markedDatesMap != null
-                              ? _renderMarkedMapContainer(now)
-                              : Container(),
-                        ],
-                      ),
-                    ),
-                  );
+                  return renderDay(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay, textStyle, defaultTextStyle, isNextMonthDay, isThisMonthDay, now);
                 }),
               ),
             ),
@@ -564,90 +595,7 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
                         now.millisecondsSinceEpoch >
                             widget.maxSelectedDate.millisecondsSinceEpoch)
                       isSelectable = false;
-                    return Container(
-                      margin: EdgeInsets.all(widget.dayPadding),
-                      child: FlatButton(
-                        color: isSelectedDay && widget.selectedDayButtonColor != null
-                          ? widget.selectedDayButtonColor
-                          : isToday && widget.todayButtonColor != null
-                              ? widget.todayButtonColor
-                              : widget.dayButtonColor,
-                        onPressed: () => _onDayPressed(now),
-                        padding: EdgeInsets.all(widget.dayPadding),
-                        shape: widget.markedDateCustomShapeBorder != null
-                          && widget.markedDatesMap != null
-                          && widget.markedDatesMap.getEvents(now).length > 0
-                          ? widget.markedDateCustomShapeBorder
-                          : widget.daysHaveCircularBorder == null
-                            ? CircleBorder()
-                            : widget.daysHaveCircularBorder?? false
-                              ? CircleBorder(
-                                  side: BorderSide(
-                                    color: isSelectedDay
-                                      ? widget.selectedDayBorderColor
-                                      : isToday && widget.todayBorderColor != null
-                                          ? widget.todayBorderColor
-                                          : isPrevMonthDay
-                                            ? widget.prevMonthDayBorderColor
-                                            : isNextMonthDay
-                                                ? widget.nextMonthDayBorderColor
-                                                : widget.thisMonthDayBorderColor,
-                                  ),
-                                )
-                              : RoundedRectangleBorder(
-                                  side: BorderSide(
-                                    color: isSelectedDay
-                                        ? widget.selectedDayBorderColor
-                                        : isToday && widget.todayBorderColor != null
-                                          ? widget.todayBorderColor
-                                          : isPrevMonthDay
-                                            ? widget.prevMonthDayBorderColor
-                                            : isNextMonthDay
-                                                ? widget.nextMonthDayBorderColor
-                                                : widget.thisMonthDayBorderColor,
-                                  ),
-                                ),
-                        child: Stack(
-                          children: <Widget>[
-                            Center(
-                              child: DefaultTextStyle(
-                                style: (index % 7 == 0 || index % 7 == 6) &&
-                                      !isSelectedDay &&
-                                      !isToday &&
-                                      !isPrevMonthDay &&
-                                      !isNextMonthDay
-                                    ? (isSelectable
-                                      ? defaultWeekendTextStyle
-                                      : defaultInactiveWeekendTextStyle)
-                                    : isToday
-                                      ? defaultTodayTextStyle
-                                      : textStyle != null
-                                        ? textStyle
-                                        : defaultTextStyle,
-                                child: Text(
-                                  '${now.day}',
-                                  style: !isSelectable && widget.inactiveDaysTextStyle != null
-                                    ? widget.inactiveDaysTextStyle
-                                    : !isSelectable
-                                      ? defaultInactiveDaysTextStyle
-                                      : (index % 7 == 0 || index % 7 == 6) &&
-                                      !isSelectedDay &&
-                                      !isToday
-                                        ? widget.weekendTextStyle
-                                        : isToday
-                                          ? widget.todayTextStyle
-                                          : textStyle,
-                                  maxLines: 1,
-                                ),
-                              ),
-                            ),
-                            widget.markedDatesMap != null
-                              ? _renderMarkedMapContainer(now)
-                              : Container(),
-                          ],
-                        ),
-                      ),
-                    );
+                    return renderDay(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay, textStyle, defaultTextStyle, isNextMonthDay, isThisMonthDay, now);
                   }),
                 ),
               ),

--- a/lib/src/calendar_header.dart
+++ b/lib/src/calendar_header.dart
@@ -45,7 +45,10 @@ class CalendarHeader extends StatelessWidget {
 
   Widget _headerTouchable() => FlatButton(
         onPressed: onHeaderTitlePressed,
-        child: Text(headerTitle, style: getTextStyle),
+        child: Text(headerTitle, 
+          semanticsLabel: headerTitle,
+          style: getTextStyle,
+        ),
       );
 
   @override

--- a/lib/src/weekday_row.dart
+++ b/lib/src/weekday_row.dart
@@ -43,6 +43,7 @@ class WeekdayRow extends StatelessWidget {
               style: defaultWeekdayTextStyle,
               child: Text(
                 weekDay,
+                semanticsLabel: weekDay,
                 style: weekdayTextStyle,
               ),
             ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_calendar_carousel
 description: Calendar widget for flutter that is swipeable. This widget can help you build customizable calendar with scrollable actions.
-version: 1.3.22
+version: 1.3.23
 author: dooboolab<dooboolab@gmail.com>
 homepage: https://github.com/dooboolab/flutter_calendar_carousel
 


### PR DESCRIPTION
Add more custom style for `Day` widget when there are `markedDates`  and `markedDateShowIcon` is false.

![Screenshot from 2019-09-14 19-53-05](https://user-images.githubusercontent.com/27461460/64907106-4f905200-d729-11e9-8e36-e41832aa22d5.png)
+ Removed deprecated methods ~~`markedDates`~~, ~~`markedDateColor`~~
+ Fixes [#101](https://github.com/dooboolab/flutter_calendar_carousel/issues/101)
+ Fixes [#104](https://github.com/dooboolab/flutter_calendar_carousel/issues/104)
+ Fixes [#112](https://github.com/dooboolab/flutter_calendar_carousel/issues/112)
+ Fixes [#119](https://github.com/dooboolab/flutter_calendar_carousel/issues/119)
+ Support long pressed as a feature request[#103](https://github.com/dooboolab/flutter_calendar_carousel/issues/103)
+ Support semantic label as a feature request [#139](https://github.com/dooboolab/flutter_calendar_carousel/issues/139)
+ Expose `dayCrossAxisAlignment` and `dayMainAxisAlignment` to resolve [#122](https://github.com/dooboolab/flutter_calendar_carousel/issues/122)
+ Expose `showIconBehindDayText` to resolve [#131](https://github.com/dooboolab/flutter_calendar_carousel/issues/131)
+ Fixes [#94](https://github.com/dooboolab/flutter_calendar_carousel/issues/94)
