### PR TITLE
Custom day container feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Widget widget() {
   return Container(
     margin: EdgeInsets.symmetric(horizontal: 16.0),
     child: CalendarCarousel<Event>(
-      onDayPressed: (DateTime date) {
+      onDayPressed: (DateTime date, List<Event> events) {
         this.setState(() => _currentDate = date);
       },
       weekendTextStyle: TextStyle(
@@ -111,6 +111,29 @@ Widget widget() {
 //      headerText: Container( /// Example for rendering custom header
 //        child: Text('Custom Header'),
 //      ),
+      customDayBuilder: (   /// you can provide your own build function to make custom day containers
+        bool isSelectable,
+        int index,
+        bool isSelectedDay,
+        bool isToday,
+        bool isPrevMonthDay,
+        TextStyle textStyle,
+        bool isNextMonthDay,
+        bool isThisMonthDay,
+        DateTime day,
+      ) {
+          /// If you return null, [CalendarCarousel] will build container for current [day] with default function.
+          /// This way you can build custom containers for specific days only, leaving rest as default.
+
+          // Example: every 15th of month, we have a flight, we can place an icon in the container like that:
+          if (day.day == 15) {
+            return Center(
+              child: Icon(Icons.local_airport),
+            );
+          } else {
+            return null;
+          }
+      },
       weekFormat: false,
       markedDatesMap: _markedDateMap,
       height: 420.0,

--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -26,6 +26,11 @@ typedef void OnDayLongPressed(DateTime day);
 /// [isSelectedDay] - if the day is selected
 /// [isToday] - if the day is similar to [DateTime.now()]
 /// [isPrevMonthDay] - if the day is from previous month
+/// [textStyle] - text style that would have been applied by the calendar if it was to build the day.
+/// Example: if the user provided [CalendarCarousel.todayTextStyle] and [isToday] is true,
+///   [CalendarCarousel.todayTextStyle] would be sent into [DayBuilder]'s [textStyle]. If user didn't
+///   provide it, default [CalendarCarousel]'s textStyle would be sent. Same applies to all text styles like
+///   [CalendarCarousel.prevDaysTextStyle], [CalendarCarousel.daysTextStyle] etc.
 /// [isNextMonthDay] - if the day is from next month
 /// [isThisMonthDay] - if the day is from next month
 /// [day] - day being built.
@@ -35,6 +40,7 @@ typedef Widget DayBuilder(
     bool isSelectedDay,
     bool isToday,
     bool isPrevMonthDay,
+    TextStyle textStyle,
     bool isNextMonthDay,
     bool isThisMonthDay,
     DateTime day
@@ -338,45 +344,13 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
         mainAxisAlignment: widget.dayMainAxisAlignment,
         children: <Widget>[
           DefaultTextStyle(
-            style: !isSelectable
-            ?  defaultInactiveDaysTextStyle
-            : (_localeDate.dateSymbols.WEEKENDRANGE.contains(
-                (index - 1 + firstDayOfWeek) % 7)) && !isSelectedDay && !isToday
-              ? (isPrevMonthDay
-                ? defaultPrevDaysTextStyle
-                : isNextMonthDay
-                  ? defaultNextDaysTextStyle
-                  : isSelectable
-                    ? defaultWeekendTextStyle
-                    : defaultInactiveWeekendTextStyle)
-              : isToday
-                ? defaultTodayTextStyle
-                : isSelectable && textStyle != null
-                    ? textStyle
-                    : defaultTextStyle,
+            style: getDefaultDayStyle(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay,
+                textStyle, defaultTextStyle, isNextMonthDay, isThisMonthDay),
               child: Text(
                 '${now.day}',
                 semanticsLabel: now.day.toString(),
-                style:
-                  isSelectedDay && widget.selectedDayTextStyle != null
-                  ? widget.selectedDayTextStyle
-                  : (_localeDate.dateSymbols.WEEKENDRANGE.contains(
-                  (index - 1 + firstDayOfWeek) % 7))
-                  && !isSelectedDay
-                  && isThisMonthDay
-                  && !isToday
-                  ? (isSelectable
-                      ? widget.weekendTextStyle
-                      : widget.inactiveWeekendTextStyle)
-                  : !isSelectable
-                  ? widget.inactiveDaysTextStyle
-                  : isPrevMonthDay
-                      ? widget.prevDaysTextStyle
-                      : isNextMonthDay
-                        ? widget.nextDaysTextStyle
-                        : isToday
-                            ? widget.todayTextStyle
-                            : widget.daysTextStyle,
+                style: getDayStyle(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay,
+                textStyle, defaultTextStyle, isNextMonthDay, isThisMonthDay),
                 maxLines: 1,
               ),
           ),
@@ -449,17 +423,11 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
                 widget.markedDatesMap != null
                     ? _renderMarkedMapContainer(now)
                     : Container(),
-                widget.customDayBuilder != null
-                    ? widget.customDayBuilder(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay, isNextMonthDay, isThisMonthDay, now)
-                      ?? getDefaultDayContainer(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay, textStyle, defaultTextStyle, isNextMonthDay, isThisMonthDay, now)
-                    : getDefaultDayContainer(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay, textStyle, defaultTextStyle, isNextMonthDay, isThisMonthDay, now),
+                getDayContainer(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay, textStyle, defaultTextStyle, isNextMonthDay, isThisMonthDay, now),
               ]
               : <Widget>[
-                widget.customDayBuilder != null
-                    ? widget.customDayBuilder(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay, isNextMonthDay, isThisMonthDay, now)
-                     ?? getDefaultDayContainer(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay, textStyle, defaultTextStyle, isNextMonthDay, isThisMonthDay, now)
-                    : getDefaultDayContainer(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay, textStyle, defaultTextStyle, isNextMonthDay, isThisMonthDay, now),
-               widget.markedDatesMap != null
+                getDayContainer(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay, textStyle, defaultTextStyle, isNextMonthDay, isThisMonthDay, now),
+                widget.markedDatesMap != null
                     ? _renderMarkedMapContainer(now)
                     : Container(),
               ],
@@ -939,5 +907,89 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
       return tmp;
     }
     return [];
+  }
+
+  TextStyle getDefaultDayStyle(
+      bool isSelectable,
+      int index,
+      bool isSelectedDay,
+      bool isToday,
+      bool isPrevMonthDay,
+      TextStyle textStyle,
+      TextStyle defaultTextStyle,
+      bool isNextMonthDay,
+      bool isThisMonthDay,
+      ) {
+    return !isSelectable
+        ?  defaultInactiveDaysTextStyle
+        : (_localeDate.dateSymbols.WEEKENDRANGE.contains(
+        (index - 1 + firstDayOfWeek) % 7)) && !isSelectedDay && !isToday
+        ? (isPrevMonthDay
+        ? defaultPrevDaysTextStyle
+        : isNextMonthDay
+        ? defaultNextDaysTextStyle
+        : isSelectable
+        ? defaultWeekendTextStyle
+        : defaultInactiveWeekendTextStyle)
+        : isToday
+        ? defaultTodayTextStyle
+        : isSelectable && textStyle != null
+        ? textStyle
+        : defaultTextStyle;
+  }
+
+  TextStyle getDayStyle(
+      bool isSelectable,
+      int index,
+      bool isSelectedDay,
+      bool isToday,
+      bool isPrevMonthDay,
+      TextStyle textStyle,
+      TextStyle defaultTextStyle,
+      bool isNextMonthDay,
+      bool isThisMonthDay,
+      ) {
+    return isSelectedDay && widget.selectedDayTextStyle != null
+        ? widget.selectedDayTextStyle
+        : (_localeDate.dateSymbols.WEEKENDRANGE.contains(
+        (index - 1 + firstDayOfWeek) % 7))
+        && !isSelectedDay
+        && isThisMonthDay
+        && !isToday
+        ? (isSelectable
+        ? widget.weekendTextStyle
+        : widget.inactiveWeekendTextStyle)
+        : !isSelectable
+        ? widget.inactiveDaysTextStyle
+        : isPrevMonthDay
+        ? widget.prevDaysTextStyle
+        : isNextMonthDay
+        ? widget.nextDaysTextStyle
+        : isToday
+        ? widget.todayTextStyle
+        : widget.daysTextStyle;
+  }
+
+  Widget getDayContainer(
+      bool isSelectable,
+      int index,
+      bool isSelectedDay,
+      bool isToday,
+      bool isPrevMonthDay,
+      TextStyle textStyle,
+      TextStyle defaultTextStyle,
+      bool isNextMonthDay,
+      bool isThisMonthDay,
+      DateTime now) {
+    if (widget.customDayBuilder != null) {
+      TextStyle styleForBuilder = getDayStyle(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay, textStyle, defaultTextStyle, isNextMonthDay, isThisMonthDay);
+      if (styleForBuilder == null) {
+        styleForBuilder = getDefaultDayStyle(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay, textStyle, defaultTextStyle, isNextMonthDay, isThisMonthDay);
+      }
+      return widget.customDayBuilder(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay, styleForBuilder, isNextMonthDay, isThisMonthDay, now)
+             ?? getDefaultDayContainer(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay, textStyle, defaultTextStyle, isNextMonthDay, isThisMonthDay, now);
+    } else {
+      return getDefaultDayContainer(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay, textStyle, defaultTextStyle, isNextMonthDay, isThisMonthDay, now);
+    }
   }
 }

--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -19,6 +19,7 @@ typedef void OnDayLongPressed(DateTime day);
 
 /// This builder is called for every day in the calendar.
 /// If you want to build only few custom day containers, return null for the days you want to leave with default looks
+/// All characteristics like circle border are also applied to the custom day container [DayBuilder] provides.
 /// (if supplied function returns null, Calendar's function will be called for [day]).
 /// [isSelectable] - is between [CalendarCarousel.minSelectedDate] and [CalendarCarousel.maxSelectedDate]
 /// [index] - DOES NOT equal day number! Index of the day built in current visible field

--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -16,6 +16,29 @@ export 'package:flutter_calendar_carousel/classes/event_list.dart';
 typedef MarkedDateIconBuilder<Event> = Widget Function(Event event);
 typedef void OnDayLongPressed(DateTime day);
 
+
+/// This builder is called for every day in the calendar.
+/// If you want to build only few custom day containers, return null for the days you want to leave with default looks
+/// (if supplied function returns null, Calendar's function will be called for [day]).
+/// [isSelectable] - is between [CalendarCarousel.minSelectedDate] and [CalendarCarousel.maxSelectedDate]
+/// [index] - DOES NOT equal day number! Index of the day built in current visible field
+/// [isSelectedDay] - if the day is selected
+/// [isToday] - if the day is similar to [DateTime.now()]
+/// [isPrevMonthDay] - if the day is from previous month
+/// [isNextMonthDay] - if the day is from next month
+/// [isThisMonthDay] - if the day is from next month
+/// [day] - day being built.
+typedef Widget DayBuilder(
+    bool isSelectable,
+    int index,
+    bool isSelectedDay,
+    bool isToday,
+    bool isPrevMonthDay,
+    bool isNextMonthDay,
+    bool isThisMonthDay,
+    DateTime day
+    );
+
 class CalendarCarousel<T> extends StatefulWidget {
   final double viewportFraction;
   final TextStyle prevDaysTextStyle;
@@ -67,6 +90,7 @@ class CalendarCarousel<T> extends StatefulWidget {
   final EdgeInsets weekDayMargin;
   final EdgeInsets weekDayPadding;
   final WeekdayBuilder customWeekDayBuilder;
+  final DayBuilder customDayBuilder;
   final Color weekDayBackgroundColor;
   final bool weekFormat;
   final bool showWeekDays;
@@ -139,6 +163,7 @@ class CalendarCarousel<T> extends StatefulWidget {
     this.weekDayPadding = const EdgeInsets.all(0.0),
     this.weekDayBackgroundColor = Colors.transparent,
     this.customWeekDayBuilder,
+    this.customDayBuilder,
     this.showWeekDays = true,
     this.weekFormat = false,
     this.showHeader = true,
@@ -292,7 +317,7 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
     );
   }
 
-  Widget getDayContainer(
+  Widget getDefaultDayContainer(
     bool isSelectable,
     int index,
     bool isSelectedDay,
@@ -423,11 +448,17 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
                 widget.markedDatesMap != null
                     ? _renderMarkedMapContainer(now)
                     : Container(),
-                getDayContainer(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay, textStyle, defaultTextStyle, isNextMonthDay, isThisMonthDay, now),
+                widget.customDayBuilder != null
+                    ? widget.customDayBuilder(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay, isNextMonthDay, isThisMonthDay, now)
+                      ?? getDefaultDayContainer(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay, textStyle, defaultTextStyle, isNextMonthDay, isThisMonthDay, now)
+                    : getDefaultDayContainer(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay, textStyle, defaultTextStyle, isNextMonthDay, isThisMonthDay, now),
               ]
               : <Widget>[
-                getDayContainer(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay, textStyle, defaultTextStyle, isNextMonthDay, isThisMonthDay, now),
-                widget.markedDatesMap != null
+                widget.customDayBuilder != null
+                    ? widget.customDayBuilder(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay, isNextMonthDay, isThisMonthDay, now)
+                     ?? getDefaultDayContainer(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay, textStyle, defaultTextStyle, isNextMonthDay, isThisMonthDay, now)
+                    : getDefaultDayContainer(isSelectable, index, isSelectedDay, isToday, isPrevMonthDay, textStyle, defaultTextStyle, isNextMonthDay, isThisMonthDay, now),
+               widget.markedDatesMap != null
                     ? _renderMarkedMapContainer(now)
                     : Container(),
               ],


### PR DESCRIPTION
Added a way to provide custom build function for days. All properties like circle border are also applied to custom day container. Text style is also sent into the builder, if user provided one in Calendar's properties suitable for current day. If user didn't provide any, default text style is sent into user's build function.

If user's build function returns null, default container method is called, which gives user an opportunity to provide build function only for a specific day, leaving rest as default.