### PR TITLE
Allow the use of generic type with Interface

### DIFF
--- a/lib/classes/event.dart
+++ b/lib/classes/event.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-class Event {
+class Event implements EventInterface {
   final DateTime date;
   final String title;
   final Widget icon;
@@ -11,8 +11,7 @@ class Event {
     this.title,
     this.icon,
     this.dot,
-  })
-  : assert(date != null);
+  }) : assert(date != null);
 
   @override
   bool operator ==(dynamic other) {
@@ -24,4 +23,31 @@ class Event {
 
   @override
   int get hashCode => hashValues(date, title, icon);
+
+  @override
+  DateTime getDate() {
+    return date;
+  }
+
+  @override
+  Widget getDot() {
+    return dot;
+  }
+
+  @override
+  Widget getIcon() {
+    return icon;
+  }
+
+  @override
+  String getTitle() {
+    return title;
+  }
+}
+
+abstract class EventInterface {
+  DateTime getDate();
+  String getTitle();
+  Widget getIcon();
+  Widget getDot();
 }

--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -12,7 +12,7 @@ import 'package:intl/date_symbol_data_local.dart';
 import 'package:intl/intl.dart' show DateFormat;
 export 'package:flutter_calendar_carousel/classes/event_list.dart';
 
-typedef MarkedDateIconBuilder<Event> = Widget Function(Event event);
+typedef MarkedDateIconBuilder<T> = Widget Function(T event);
 typedef void OnDayLongPressed(DateTime day);
 
 
@@ -45,7 +45,7 @@ typedef Widget DayBuilder(
     DateTime day
     );
 
-class CalendarCarousel<T> extends StatefulWidget {
+class CalendarCarousel<T extends EventInterface> extends StatefulWidget {
   final double viewportFraction;
   final TextStyle prevDaysTextStyle;
   final TextStyle daysTextStyle;
@@ -71,7 +71,7 @@ class CalendarCarousel<T> extends StatefulWidget {
   final TextStyle headerTextStyle;
   final String headerText;
   final TextStyle weekendTextStyle;
-  final EventList<Event> markedDatesMap;
+  final EventList<T> markedDatesMap;
   /// Change `makredDateWidget` when `markedDateShowIcon` is set to false.
   final Widget markedDateWidget;
   /// Change `ShapeBorder` when `markedDateShowIcon` is set to false.
@@ -86,7 +86,7 @@ class CalendarCarousel<T> extends StatefulWidget {
   final int markedDateIconMaxShown;
   final double markedDateIconMargin;
   final double markedDateIconOffset;
-  final MarkedDateIconBuilder<Event> markedDateIconBuilder;
+  final MarkedDateIconBuilder<T> markedDateIconBuilder;
   /// null - no indicator, true - show the total events, false - show the total of hidden events
   final bool markedDateMoreShowTotal;
   final Decoration markedDateMoreCustomDecoration;
@@ -210,7 +210,7 @@ enum WeekdayFormat {
   standaloneNarrow,
 }
 
-class _CalendarState<T> extends State<CalendarCarousel<T>> {
+class _CalendarState<T extends EventInterface> extends State<CalendarCarousel<T>> {
   PageController _controller;
   List<DateTime> _dates = List(3);
   List<List<DateTime>> _weeks = List(3);
@@ -856,7 +856,7 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
       int eventIndex = 0;
       double offset = 0.0;
       double padding = widget.markedDateIconMargin;
-      widget.markedDatesMap.getEvents(now).forEach((Event event) {
+      widget.markedDatesMap.getEvents(now).forEach((T event) {
         if (widget.markedDateShowIcon) {
           if (tmp.length > 0 && tmp.length < widget.markedDateIconMaxShown) {
             offset += widget.markedDateIconOffset;
@@ -920,8 +920,8 @@ class _CalendarState<T> extends State<CalendarCarousel<T>> {
             if (widget.markedDateIconBuilder != null) {
               tmp.add(widget.markedDateIconBuilder(event));
             } else {
-              if (event.dot != null) {
-                tmp.add(event.dot);
+              if (event.getDot() != null) {
+                tmp.add(event.getDot());
               }
               else if (widget.markedDateWidget != null) {
                 tmp.add(widget.markedDateWidget);


### PR DESCRIPTION
I created an interface with the methods to get the default fields of the event class and implemented it.
I then changed each occurrence of Event class with T class that extends the interface.

This will allow us to make the plugin work with any custom class (as I already do in some of my projects).

Of course with the default Event class it will continue to work because it implements EventInterface.