### PR TITLE
add custom_header

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -148,6 +148,44 @@ class _MyHomePageState extends State<MyHomePage> {
     super.initState();
   }
 
+  Widget _customHeader({headerTitle,
+    headerMargin,
+    showHeader,
+    headerTextStyle,
+    showHeaderButtons,
+    headerIconColor,
+    leftButtonIcon,
+    rightButtonIcon,
+    onLeftButtonPressed,
+    onRightButtonPressed,
+    isTitleTouchable,
+    onHeaderTitlePressed}){
+    return  new Row(
+      children: <Widget>[
+        Expanded(
+            child: Text(
+              headerTitle,
+              style: TextStyle(
+                fontWeight: FontWeight.bold,
+                fontSize: 24.0,
+              ),
+            )),
+        FlatButton(
+          child: Text('PREV'),
+          onPressed: () {
+            onLeftButtonPressed();
+          },
+        ),
+        FlatButton(
+          child: Text('NEXT'),
+          onPressed: () {
+            onRightButtonPressed();
+          },
+        )
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     /// Example with custom icon
@@ -217,7 +255,7 @@ class _MyHomePageState extends State<MyHomePage> {
         fontSize: 18,
         color: Colors.blue,
       ),
-      showHeader: false,
+      customHeaderBuilder: _customHeader,
       // markedDateIconBuilder: (event) {
       //   return Container(
       //     color: Colors.blue,
@@ -263,47 +301,6 @@ class _MyHomePageState extends State<MyHomePage> {
                 child: _calendarCarousel,
               ), // This trailing comma makes auto-formatting nicer for build methods.
               //custom icon without header
-              Container(
-                margin: EdgeInsets.only(
-                  top: 30.0,
-                  bottom: 16.0,
-                  left: 16.0,
-                  right: 16.0,
-                ),
-                child: new Row(
-                  children: <Widget>[
-                    Expanded(
-                        child: Text(
-                      _currentMonth,
-                      style: TextStyle(
-                        fontWeight: FontWeight.bold,
-                        fontSize: 24.0,
-                      ),
-                    )),
-                    FlatButton(
-                      child: Text('PREV'),
-                      onPressed: () {
-                        setState(() {
-                          _currentDate2 =
-                              _currentDate2.subtract(Duration(days: 30));
-                          _currentMonth =
-                              DateFormat.yMMM().format(_currentDate2);
-                        });
-                      },
-                    ),
-                    FlatButton(
-                      child: Text('NEXT'),
-                      onPressed: () {
-                        setState(() {
-                          _currentDate2 = _currentDate2.add(Duration(days: 30));
-                          _currentMonth =
-                              DateFormat.yMMM().format(_currentDate2);
-                        });
-                      },
-                    )
-                  ],
-                ),
-              ),
               Container(
                 margin: EdgeInsets.symmetric(horizontal: 16.0),
                 child: _calendarCarouselNoHeader,

--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -50,6 +50,21 @@ typedef Widget DayBuilder(
 /// [weekdayName] - string representation of the weekday (Mon, Tue, Wed, etc).
 typedef Widget WeekdayBuilder(int weekday, String weekdayName);
 
+typedef Widget HeaderBuilder({
+    @required headerTitle,
+    headerMargin,
+    showHeader,
+    headerTextStyle,
+    showHeaderButtons,
+    headerIconColor,
+    leftButtonIcon,
+    rightButtonIcon,
+    @required onLeftButtonPressed,
+    @required onRightButtonPressed,
+    isTitleTouchable,
+    @required onHeaderTitlePressed
+    });
+
 class CalendarCarousel<T extends EventInterface> extends StatefulWidget {
   final double viewportFraction;
   final TextStyle prevDaysTextStyle;
@@ -102,6 +117,7 @@ class CalendarCarousel<T extends EventInterface> extends StatefulWidget {
   final EdgeInsets weekDayPadding;
   final WeekdayBuilder customWeekDayBuilder;
   final DayBuilder customDayBuilder;
+  final HeaderBuilder customHeaderBuilder;
   final Color weekDayBackgroundColor;
   final bool weekFormat;
   final bool showWeekDays;
@@ -177,6 +193,7 @@ class CalendarCarousel<T extends EventInterface> extends StatefulWidget {
     this.weekDayBackgroundColor = Colors.transparent,
     this.customWeekDayBuilder,
     this.customDayBuilder,
+    this.customHeaderBuilder,
     this.showWeekDays = true,
     this.weekFormat = false,
     this.showHeader = true,
@@ -294,7 +311,26 @@ class _CalendarState<T extends EventInterface> extends State<CalendarCarousel<T>
       height: widget.height,
       child: Column(
         children: <Widget>[
-          CalendarHeader(
+          widget.customHeaderBuilder != null ? widget.customHeaderBuilder(
+            showHeader: widget.showHeader,
+            headerMargin: widget.headerMargin,
+            headerTitle: widget.headerText != null
+                ? widget.headerText
+                : widget.weekFormat
+                ? '${_localeDate.format(this._weeks[this._pageNum].first)}'
+                : '${_localeDate.format(this._dates[this._pageNum])}',
+            headerTextStyle: widget.headerTextStyle,
+            showHeaderButtons: widget.showHeaderButton,
+            headerIconColor: widget.iconColor,
+            leftButtonIcon: widget.leftButtonIcon,
+            rightButtonIcon: widget.rightButtonIcon,
+            onLeftButtonPressed: () => this._pageNum > 0 ? _setDate(this._pageNum - 1) : null,
+            onRightButtonPressed: () => widget.weekFormat ? (this._weeks.length -1 > this._pageNum ? _setDate(this._pageNum + 1) : null) : (this._dates.length - 1 > this._pageNum ? _setDate(this._pageNum + 1) : null),
+            isTitleTouchable: widget.headerTitleTouchable,
+            onHeaderTitlePressed: widget.onHeaderTitlePressed != null
+                ? widget.onHeaderTitlePressed
+                : () => _selectDateFromPicker(),
+          ) : CalendarHeader(
             showHeader: widget.showHeader,
             headerMargin: widget.headerMargin,
             headerTitle: widget.headerText != null


### PR DESCRIPTION
#172 
could not be created custom header, so added the ability to create it.

The header of ```_calendarCarouselNoHeader``` in ```example/lib/main.dart``` has been changed to work correctly.