### PR TITLE
Update intl dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.0.0 <3.0.0"
 
 dependencies:
-  intl: ">=0.1.0 <0.17.0"
+  intl: ">=0.1.0 <0.18.0"
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
flutter_calendar_carousel doesn't work with the new Flutter beta any more:

```
Because flutter_calendar_carousel 1.5.1 depends on intl >=0.1.0 <0.17.0 and no versions of flutter_calendar_carousel match >1.5.1 <2.0.0, flutter_calendar_carousel ^1.5.1 requires intl >=0.1.0 <0.17.0.

So, because (app name) depends on both flutter_calendar_carousel ^1.5.1 and intl ^0.17.0-nullsafety.2, version solving failed.
pub get failed (1; So, because (app name) depends on both flutter_calendar_carousel ^1.5.1 and intl ^0.17.0-nullsafety.2, version solving failed.)
exit code 1
```

Since the last intl version 0.16.1 only sdk constraints were changed, so it should be safe to support 0.17.x:
https://github.com/dart-lang/intl/commits/master

FYI if one does not update intl with Flutter beta, you get this error:

```
Because every version of flutter_localizations from sdk depends on intl 0.17.0-nullsafety.2 and (app name) depends on intl ^0.16.1, flutter_localizations from sdk is forbidden.

So, because (app name) depends on flutter_localizations any from sdk, version solving failed.
pub get failed (1; So, because (app name) depends on flutter_localizations any from sdk, version solving failed.)
exit code 1
```

```
dev_dependencies:
  flutter_localizations:
    sdk: flutter
```