### PR TITLE
fix: flutter 3.0 upgrade

### DIFF
--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -947,7 +947,7 @@ class _CalendarState<T extends EventInterface>
       //call callback
       final onCalendarChanged = widget.onCalendarChanged;
       if (onCalendarChanged != null) {
-        WidgetsBinding?.instance.addPostFrameCallback((_) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
           onCalendarChanged(!widget.weekFormat
               ? this._dates[page]
               : this._weeks[page][firstDayOfWeek]);


### PR DESCRIPTION
The class 'WidgetsBinding' cannot be null. Try replacing '?.' with '.'