### PR TITLE
Add ability to upper case week days text by setting `upperCaseWeekDays`

### DIFF
--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -111,6 +111,7 @@ class CalendarCarousel<T extends EventInterface> extends StatefulWidget {
   final Color weekDayBackgroundColor;
   final bool weekFormat;
   final bool showWeekDays;
+  final bool upperCaseWeekDays;
   final bool showHeader;
   final bool showHeaderButton;
   final MultipleMarkedDates? multipleMarkedDates;
@@ -195,6 +196,7 @@ class CalendarCarousel<T extends EventInterface> extends StatefulWidget {
       this.customWeekDayBuilder,
       this.customDayBuilder,
       this.showWeekDays = true,
+      this.upperCaseWeekDays = false,
       this.weekFormat = false,
       this.showHeader = true,
       this.showHeaderButton = true,
@@ -382,6 +384,7 @@ class _CalendarState<T extends EventInterface>
             firstDayOfWeek,
             widget.customWeekDayBuilder,
             showWeekdays: widget.showWeekDays,
+            upperCaseWeekDays: widget.upperCaseWeekDays,
             weekdayFormat: widget.weekDayFormat,
             weekdayMargin: widget.weekDayMargin,
             weekdayPadding: widget.weekDayPadding,

--- a/lib/src/weekday_row.dart
+++ b/lib/src/weekday_row.dart
@@ -13,7 +13,8 @@ class WeekdayRow extends StatelessWidget {
       required this.weekdayPadding,
       required this.weekdayBackgroundColor,
       required this.weekdayTextStyle,
-      required this.localeDate})
+      required this.localeDate,
+      this.upperCaseWeekDays = false})
       : super(key: key);
 
   final WeekdayBuilder? customWeekdayBuilder;
@@ -25,6 +26,7 @@ class WeekdayRow extends StatelessWidget {
   final TextStyle? weekdayTextStyle;
   final DateFormat localeDate;
   final int firstDayOfWeek;
+  final bool upperCaseWeekDays;
 
   Widget _weekdayContainer(int weekday, String weekDayName) {
     final customWeekdayBuilder = this.customWeekdayBuilder;
@@ -42,7 +44,7 @@ class WeekdayRow extends StatelessWidget {
               child: DefaultTextStyle(
                 style: defaultWeekdayTextStyle,
                 child: Text(
-                  weekDayName,
+                  upperCaseWeekDays ? weekDayName.toUpperCase() : weekDayName,
                   semanticsLabel: weekDayName,
                   style: weekdayTextStyle,
                 ),

--- a/lib/src/weekday_row.dart
+++ b/lib/src/weekday_row.dart
@@ -30,7 +30,11 @@ class WeekdayRow extends StatelessWidget {
   final int firstDayOfWeek;
   final bool upperCaseWeekdays;
 
-  Widget _weekdayContainer(int weekday, String weekDayName) {
+  Widget _weekdayContainer(
+    int weekday,
+    String weekDayName, {
+    String? semanticsLabel,
+  }) {
     final customWeekdayBuilder = this.customWeekdayBuilder;
     return customWeekdayBuilder != null
         ? customWeekdayBuilder(weekday, weekDayName)
@@ -47,7 +51,7 @@ class WeekdayRow extends StatelessWidget {
                   style: defaultWeekdayTextStyle,
                   child: Text(
                     weekDayName,
-                    semanticsLabel: weekDayName,
+                    semanticsLabel: semanticsLabel ?? weekDayName,
                     style: weekdayTextStyle,
                   ),
                 ),
@@ -121,8 +125,12 @@ class WeekdayRow extends StatelessWidget {
           weekDay = localeDate.dateSymbols.STANDALONENARROWWEEKDAYS[i];
           break;
       }
-      weekDay = upperCaseWeekdays ? weekDay.toUpperCase() : weekDay;
-      list.add(_weekdayContainer(count, weekDay));
+      final displayWeekDay = upperCaseWeekdays
+          ? weekDay.toUpperCase()
+          : weekDay;
+      list.add(
+        _weekdayContainer(count, displayWeekDay, semanticsLabel: weekDay),
+      );
     }
 
     return list;

--- a/test/src/weekday_row_test.dart
+++ b/test/src/weekday_row_test.dart
@@ -135,6 +135,9 @@ void main() {
     expect(find.text('SUN'), findsOneWidget);
     expect(find.text('MON'), findsOneWidget);
     expect(find.text('Sun'), findsNothing);
+
+    final sundayText = tester.widget<Text>(find.text('SUN'));
+    expect(sundayText.semanticsLabel, 'Sun');
   });
 
   testWidgets('passes uppercase labels to custom weekday builder', (


### PR DESCRIPTION
Non-breaking change
Adds support for an optional parameter `upperCaseWeekDays`, which makes weekDays text uppercase 