### PR TITLE
chore(deps): bump flutter_lints to ^6.0.0 and raise Dart SDK floor to ^3.8

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -13,7 +13,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.12.0 <=4.0.0'
+  sdk: '>=3.8.0 <4.0.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -50,7 +50,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.5.4
 homepage: https://github.com/hyochan/flutter_calendar_carousel
 
 environment:
-  sdk: '>=2.14.0 <4.0.0'
+  sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
   flutter:
@@ -14,7 +14,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
## Summary

- Bump `flutter_lints` from `^5.0.0` to `^6.0.0` (latest stable, published 2025-05-27).
- Raise `environment.sdk` floor from `>=2.14.0` to `>=3.8.0` — required by `flutter_lints ^6.0.0`, and brings the package in line with current Flutter stable (Dart 3.8 ≈ Flutter 3.32).
- Align `example/pubspec.yaml` (`sdk: '>=3.8.0 <4.0.0'`, `flutter_lints: ^6.0.0`) for consistency.
- `intl` constraint (`>=0.19.0 <0.21.0`) was already widened in #397 / 2.5.4 — no change needed here.

## Rationale

Regular maintenance pass. `flutter_lints 6.0.0` requires Dart SDK `^3.8.0`, so the SDK floor has to move with it. Previous `>=2.14.0` floor has been well below what modern Flutter stable supports and below what `flutter_lints 5.x` actually required (`^3.5.0`), so this also fixes a latent inconsistency.

## Test plan

- [ ] CI `flutter analyze` green on `chore/deps-20260423`
- [ ] CI `dart format --set-exit-if-changed .` green
- [ ] CI `flutter test` green
- [ ] `flutter pub publish --dry-run` clean (new lints may flag existing code — if so, fix in follow-up commits on this branch before merge)
- [ ] Example app `flutter pub get` resolves cleanly

Local toolchain wasn't available in the environment this PR was prepared in, so CI is the primary gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)