### PR TITLE
chore(deps): bump example dependencies

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -45,10 +45,10 @@ packages:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
+      sha256: "41e005c33bd814be4d3096aff55b1908d419fde52ca656c8c47719ec745873cd"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.8"
+    version: "1.0.9"
   fake_async:
     dependency: transitive
     description:
@@ -76,7 +76,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.5.5"
+    version: "2.6.0"
   flutter_driver:
     dependency: transitive
     description: flutter
@@ -109,10 +109,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.0"
+    version: "0.20.2"
   leak_tracker:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  intl: ^0.19.0
+  intl: ^0.20.2
 
   flutter_calendar_carousel:
     # When depending on this package from a real application you should use:


### PR DESCRIPTION
## Summary
- Bump the example app `intl` constraint to `^0.20.2`.
- Refresh `example/pubspec.lock`, including `cupertino_icons` 1.0.9 and the current path dependency version 2.6.0.

## Verification
- `flutter pub get`
- `flutter analyze`
- `dart format --set-exit-if-changed .`
- `flutter test --coverage` (19 passed)
- `dart pub publish --dry-run` (0 warnings after commit)

Automation: flutter-calendar-carousel-daily weekly dependency block.
