### PR TITLE
chore: refresh example lockfile

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -76,7 +76,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.6.1"
+    version: "2.6.2"
   flutter_driver:
     dependency: transitive
     description: flutter


### PR DESCRIPTION
## Summary
- refresh `example/pubspec.lock` so the example path dependency matches package version `2.6.2`
- keep the release-workflow root cause tracked in #409

Refs #409.

## Verification
- `flutter pub get`
- `flutter pub outdated`
- `flutter pub outdated --json`
- `flutter analyze`
- `dart format --set-exit-if-changed .`
- `dart pub publish --dry-run`
- `flutter test --coverage`