### PR TITLE
ci: refresh lockfiles during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,6 +158,12 @@ jobs:
           sed -i -E "s/^version: .*/version: ${NEW_VERSION}/" pubspec.yaml
           grep '^version:' pubspec.yaml
 
+      - name: Refresh lockfiles
+        if: inputs.version != 'current'
+        run: |
+          flutter pub get
+          (cd example && flutter pub get)
+
       - name: Regenerate CHANGELOG section
         env:
           NEW_VERSION: ${{ steps.bump.outputs.new_version }}
@@ -197,7 +203,7 @@ jobs:
           TAG: ${{ steps.bump.outputs.tag }}
         run: |
           set -euo pipefail
-          git add pubspec.yaml CHANGELOG.md
+          git add pubspec.yaml CHANGELOG.md pubspec.lock example/pubspec.lock
           if git diff --cached --quiet; then
             echo "Nothing to commit (likely 'current' bump)."
           else

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -76,7 +76,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.6.1"
+    version: "2.6.2"
   flutter_driver:
     dependency: transitive
     description: flutter


### PR DESCRIPTION
## Summary

Fixes #409.

- refresh root and example lockfiles after automated release version bumps
- include `pubspec.lock` and `example/pubspec.lock` in the release commit
- update the current example lockfile path dependency from `2.6.1` to `2.6.2`

## Validation

- `flutter pub get`
- `flutter analyze`
- `dart format --set-exit-if-changed .`
- `flutter test --coverage` (19 passed, 50.54% line coverage)
- `dart pub publish --dry-run` (0 warnings, existing version-sequence hint only)
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`

## Auto-merge note

This PR touches `.github/workflows/release.yml`, which is a guarded release workflow path under the daily runbook. It should receive human review and should not be auto-merged by the maintenance bot.
