### PR TITLE
chore: sync example lockfile version

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -76,7 +76,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.6.1"
+    version: "2.6.2"
   flutter_driver:
     dependency: transitive
     description: flutter


### PR DESCRIPTION
## Summary

- refresh `example/pubspec.lock` so the local path dependency records package version 2.6.2
- keeps the example lockfile aligned with the current release version after `flutter pub get`

## Validation

- `flutter pub get`
- `flutter analyze`
- `dart format --set-exit-if-changed .`
- `flutter pub publish --dry-run`
- `flutter test --coverage` (19 passed, 49.61% line coverage)
