### PR TITLE
chore: sync example lockfile version

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -76,7 +76,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.6.2"
+    version: "2.6.3"
   flutter_driver:
     dependency: transitive
     description: flutter


### PR DESCRIPTION
## Summary\n- sync the example lockfile path dependency version with pubspec.yaml 2.6.3\n\n## Verification\n- flutter pub get\n- flutter pub outdated\n- flutter analyze\n- dart format --set-exit-if-changed .\n- flutter pub publish --dry-run\n- flutter test --coverage