### PR TITLE
chore: sync example lockfile version

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -76,7 +76,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.6.2"
+    version: "2.6.3"
   flutter_driver:
     dependency: transitive
     description: flutter


### PR DESCRIPTION
## Summary
- sync the example lockfile path dependency version after the 2.6.3 release

## Verification
- flutter pub get
- flutter pub outdated
- flutter analyze
- dart format --set-exit-if-changed .
- flutter pub publish --dry-run
- flutter test --coverage