### PR TITLE
chore: sync example lockfile version

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -76,7 +76,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.6.3"
+    version: "2.6.4"
   flutter_driver:
     dependency: transitive
     description: flutter


### PR DESCRIPTION
## Summary

Follow-up for #409.

- sync the example path dependency lockfile from 2.6.3 to the current package version 2.6.4
- keep the broader release-workflow fix in #411 separate because it touches guarded workflow logic

## Validation

- flutter pub get
- flutter pub outdated
- flutter analyze
- dart format --set-exit-if-changed .
- flutter pub publish --dry-run
- dart pub publish --dry-run
- flutter test --coverage (19 passed, 50.08% line coverage)