### PR TITLE
chore: sync example lockfile version

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -76,7 +76,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.6.4"
+    version: "2.6.5"
   flutter_driver:
     dependency: transitive
     description: flutter


### PR DESCRIPTION
## Summary
- sync the example path dependency lockfile from 2.6.4 to 2.6.5 after the release bump

## Verification
- flutter pub get
- flutter pub outdated
- flutter analyze
- dart format --set-exit-if-changed .
- flutter pub publish --dry-run
- flutter test --coverage