### PR TITLE
chore: sync example lockfile version

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -76,7 +76,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.6.5"
+    version: "2.6.6"
   flutter_driver:
     dependency: transitive
     description: flutter


### PR DESCRIPTION
## Summary

- sync `example/pubspec.lock` with the latest package version after the `v2.6.6` release
- keep the lockfile-only drift tracked under #409 while #411 remains the broader guarded workflow fix

Refs #409.

## Validation

- `flutter pub get`
- `flutter pub outdated`
- `flutter analyze`
- `dart format --set-exit-if-changed .`
- `flutter pub publish --dry-run` (0 warnings, existing version-sequence hint only)
- `flutter test --coverage` (19 passed, 50.54% line coverage)