### PR TITLE
chore: sync example lockfile version

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -76,7 +76,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.6.5"
+    version: "2.6.6"
   flutter_driver:
     dependency: transitive
     description: flutter


### PR DESCRIPTION
## Summary

- sync `example/pubspec.lock` after the `v2.6.6` automated release
- keep the example path dependency aligned with root `pubspec.yaml`

Refs #409.

## Validation

- `flutter pub get`
- `flutter pub outdated`
- `flutter analyze`
- `dart format --set-exit-if-changed .`
- `flutter pub publish --dry-run` (0 warnings, existing version-sequence hint only)
- `flutter test --coverage` (19 passed, 50.54% line coverage)

## Automation note

This is a lockfile-only maintenance PR. The broader release-workflow fix remains blocked in #411 because it edits guarded release automation.
