### PR TITLE
chore: sync example lockfile version

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -76,7 +76,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.6.6"
+    version: "2.6.7"
   flutter_driver:
     dependency: transitive
     description: flutter


### PR DESCRIPTION
## Summary

Sync the example app lockfile after the automated v2.6.7 release bumped the root package version.

## Details

- Updates the generated path dependency version in example/pubspec.lock from 2.6.6 to 2.6.7.
- Keeps issue #409 moving while PR #411 remains the broader guarded release-workflow fix.

## Verification

- flutter pub get
- flutter pub outdated
- flutter analyze
- dart format --set-exit-if-changed .
- flutter pub publish --dry-run
- flutter test --coverage
