### PR TITLE
chore: sync example lockfile version

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -76,7 +76,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.6.7"
+    version: "2.6.8"
   flutter_driver:
     dependency: transitive
     description: flutter


### PR DESCRIPTION
## Summary\n- Sync the example lockfile package version after the 2.6.8 release bump.\n\n## Verification\n- flutter pub get\n- flutter pub outdated\n- flutter analyze\n- dart format --set-exit-if-changed .\n- flutter pub publish --dry-run\n- flutter test --coverage