### PR TITLE
chore: sync example lockfile version

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -76,7 +76,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.6.8"
+    version: "2.6.9"
   flutter_driver:
     dependency: transitive
     description: flutter


### PR DESCRIPTION
## Summary
- sync example/pubspec.lock with package version 2.6.9

## Verification
- flutter pub get
- flutter pub outdated
- flutter pub outdated --json
- flutter analyze
- dart format --set-exit-if-changed .
- flutter pub publish --dry-run
- flutter test --coverage
