### PR TITLE
fix(maintenance): support current Flutter and release flows

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,0 +1,32 @@
+---
+name: commit
+description: Create a branch, stage owned changes, make a Conventional Commit, push, and optionally open a pull request without implying merge authority.
+---
+
+# /commit
+
+Options may include `--push`, `--pr`, `--all`, or explicit paths. Preserve the
+user's authorization exactly; `--pr` includes push, but none of these include
+merge, tag, publish, or release authority.
+
+## Procedure
+
+1. Read `AGENTS.md`; confirm current branch, upstream, worktrees, and full status.
+2. If on `main`, create a scoped `codex/<topic>` branch unless the user supplied
+   another valid branch name.
+3. Run the relevant checks before staging.
+4. Stage only owned paths. Use `--all` only when every visible change belongs to
+   the requested task.
+5. Inspect `git diff --cached --stat`, `--name-only`, and the complete staged
+   diff. Check for secrets, generated artifacts, accidental lockfiles, and
+   unrelated edits.
+6. Commit in English with a Conventional Commit subject and a concise body when
+   the reason is not obvious.
+7. Push with upstream tracking only when authorized.
+8. Create a ready PR against `main` only when authorized. The English PR body
+   must summarize behavior/workflow changes, issue disposition, dependency and
+   Flutter compatibility, exact verification, and known external blockers.
+
+After pushing, compare local HEAD to the remote PR head. Never force-push unless
+explicitly authorized and protected with `--force-with-lease`. Never merge from
+this command.

--- a/.claude/commands/daily-routine.md
+++ b/.claude/commands/daily-routine.md
@@ -9,6 +9,12 @@ Run the sweep against fresh `origin/main`. If the current checkout is dirty or
 behind, use a detached temporary worktree and remove it afterward; never overwrite
 or stash an unrelated active checkout merely to run maintenance.
 
+Run daily quality checks with the official current stable Flutter SDK. If the
+active SDK is on `beta`, `dev`, or a stale stable revision, use an isolated SDK
+at the current stable release instead of changing the user's global checkout.
+Never report `main` as red from a beta/dev test-runner failure unless the same
+failure reproduces on current stable.
+
 ## Daily Sweep
 
 1. Fetch `origin main --tags --prune`. Record origin SHA, latest tag, commits

--- a/.claude/commands/daily-routine.md
+++ b/.claude/commands/daily-routine.md
@@ -1,124 +1,55 @@
 ---
-description: Execute the daily maintenance routine for flutter_calendar_carousel
+name: daily-routine
+description: Run the guarded maintenance sweep for flutter_calendar_carousel without overwriting local work or implicitly merging releases.
 ---
 
 # /daily-routine
 
-Run the daily maintenance sweep. This is also what the Cowork scheduled tasks trigger — running it by hand should produce the same output.
+Run the sweep against fresh `origin/main`. If the current checkout is dirty or
+behind, use a detached temporary worktree and remove it afterward; never overwrite
+or stash an unrelated active checkout merely to run maintenance.
 
-## Daily (run every weekday morning)
+## Daily Sweep
 
-1. **Repository freshness & tracking**
-   - Fetch latest remote state first: `git fetch origin main --tags --prune`.
-   - Run the sweep against latest `origin/main`. If the mounted checkout has local changes or is behind, do not overwrite it; create a unique temporary path with `TEMP_WORKTREE=$(mktemp -d) && rmdir "$TEMP_WORKTREE"`, run `git worktree add --detach "$TEMP_WORKTREE" origin/main`, and `cd "$TEMP_WORKTREE"` before all subsequent sweep steps. Report the local dirty/behind state.
-   - Remove any temporary worktree created for the sweep before the run exits. If cleanup fails, report the path as a follow-up instead of leaving it implicit.
-   - Record commit SHA, Flutter/Dart version, latest tag, commits since tag, and open issue/PR counts.
-   - Use GitHub issues for recurring blockers: red main, failed dependency bumps, Flutter stable regressions, and CI/release/publish failures.
+1. Fetch `origin main --tags --prune`. Record origin SHA, latest tag, commits
+   since tag, open issues/PRs, and exact Flutter/Dart versions.
+2. Run `flutter pub outdated --json`. Separate actionable direct/dev upgrades
+   from transitive versions constrained by Flutter/Dart.
+3. Run root format, analysis, tests with coverage, and publish dry-run.
+4. Run example `pub get`, analysis, tests, and Android debug build.
+5. Inspect failed CI, release, and publish runs plus actionable open issues and
+   PR feedback. Avoid duplicate tracking comments or issues.
+6. For each clear safe maintenance item, create one scoped branch and PR, run
+   `.claude/commands/verify-all.md`, then enter `/review-pr`.
 
-2. **Autonomous maintenance task loop**
-   - Build a daily work queue from failed sweep steps, actionable issues, PR blockers that can be fixed in the base repo, dependency/Flutter drift, CI/release/publish failures, and automation gaps.
-   - Split work into small branches. Use names like `codex/<area>-YYYYMMDD` or `chore/deps-YYYYMMDD`.
-   - Implement the smallest safe change, then run the relevant verification. Minimum for product changes: `flutter pub get`, `flutter analyze`, `dart format --set-exit-if-changed .`, `flutter test --coverage`, and `flutter pub publish --dry-run`.
-   - Commit, push, open a PR, request Copilot, post `/gemini review for $HEAD_SHA`, wait for CodeRabbit when available, and use the same 3-bot gates before merge.
-   - If CI/reviews fail, push a follow-up fix or leave the PR open with a precise blocker comment/issue.
-   - Never push directly to `main`. Never batch unrelated fixes. Never weaken lint, CI, release, publish, or security gates to make a PR pass.
-   - Do not edit contributor PR branches unless the author explicitly requested/allowed maintainer edits; create repo-owned fix PRs instead.
+Never push directly to `main`, batch unrelated fixes, edit contributor branches
+without permission, weaken a gate, merge, publish, or release without explicit
+authority.
 
-3. **Dependency check**
-   - `flutter pub outdated`
-   - `flutter pub outdated --json`
-   - Note direct/dev packages with newer compatible or resolvable versions.
-   - Separately report transitive-only latest versions blocked by Flutter/Dart constraints.
-   - If a direct/dev package remains blocked by SDK constraints or a major upgrade for more than one run, create/update `maintenance: dependency upgrade blocked`.
-   - Do not blindly upgrade from here. Safe direct/dev updates can be queued into the autonomous task loop; grouped dependency PRs normally happen in the weekly job.
+## Review Loop
 
-4. **Code quality**
-   - `flutter analyze`
-   - `dart format --set-exit-if-changed .`
-   - `flutter pub publish --dry-run`
-   - Analyze and format must pass. If they don't, surface the failure, open/update `daily-routine: analyze/format red on main`, and stop the routine.
-   - Report publish dry-run as the package publishability/breaking-risk smoke check.
+`.claude/commands/review-pr.md` and `.codex/skills/review-pr/SKILL.md` are the
+canonical review procedure. Fix valid findings, cover unavailable reviewers with
+one exact-head self-review, and poll every five minutes until two clean snapshots.
+Opening a maintenance PR does not imply permission to merge it.
 
-5. **Tests**
-   - `flutter test --coverage`
-   - Calculate coverage from `coverage/lcov.info` after the test run by summing the numeric `LH:` values as `sum(LH)` and `LF:` values as `sum(LF)`, then reporting `(sum(LF) > 0 ? sum(LH) / sum(LF) * 100 : 0)`.
-   - Report pass/fail counts. If any test fails, open (or update) a tracking issue with the failure output.
+## Issue Triage
 
-6. **PR review & auto-merge (3-bot loop)**
+- Apply existing labels when classification is clear.
+- Let the configured stale workflow handle age-based closure.
+- Link duplicates with evidence.
+- Distinguish repository fixes from external pub.dev, GitHub App, platform, or
+  Flutter limitations.
+- Create/update a tracking issue for red `main`, failed dependency upgrades,
+  Flutter stable regressions, or release/publish failures only when one does not
+  already exist.
 
-   See `.claude/commands/review-pr.md` for the canonical bot-loop spec. This section is the daily entry point for it.
+## Report
 
-   **When we open a PR from this routine** (deps bump, fix, anything):
-   The daily routine may open scoped maintenance PRs before invoking the
-   review loop. The standalone `/review-pr` command never opens PRs by itself.
+Return repository freshness, SDK versions, dependency status, format/analyze/test
+and coverage results, example build status, publish dry-run, PR review state,
+issues touched, temporary-worktree cleanup, and precise blockers.
 
-   ```bash
-   OWNER_REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
-   PR=<number>
-   HEAD_SHA=$(gh pr view "$PR" --json headRefOid --jq .headRefOid)
-   gh pr edit "$PR" --add-reviewer "copilot-pull-request-reviewer[bot]" \
-     || echo '{"reviewers":["copilot-pull-request-reviewer[bot]"]}' | gh api -X POST "repos/$OWNER_REPO/pulls/$PR/requested_reviewers" --input -
-   gh pr comment "$PR" --body "/gemini review for $HEAD_SHA"
-   # CodeRabbit auto-fires on push — no manual action.
-   ```
-
-   **Reviewing every open PR**:
-   ```bash
-   OWNER_REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
-   gh pr list --state open --json number,isDraft,author,headRefOid --repo "$OWNER_REPO"
-   ```
-
-   For each PR:
-   - **`isDraft == true`** → skip.
-   - **Author is a bot** (`dependabot[bot]`, `renovate[bot]`, `github-actions[bot]`, or ends `[bot]`) → **bot-bypass**: fetch `statusCheckRollup` and verify every reported check is completed with `SUCCESS` or `SKIPPED` before approval → `gh pr review "$PR" --approve --body "Automated bot PR — auto-merging." || true` → `gh pr merge "$PR" --auto --squash --delete-branch`. If checks are missing, pending, failed, cancelled, or timed out, record `skipped(bot-bypass-failed)` and do not approve. Do not run the 3-bot loop. CI is the gate.
-   - **Everything else** → run the full `/review-pr` flow:
-     - Step 0 prep if Copilot isn't a requested reviewer yet (assign + `/gemini review for $HEAD_SHA`).
-     - Step 1 fetch state (PR JSON, diff, checks, reviews, comments).
-     - Step 2 short-circuit gates — if any failed/cancelled check or guarded blocker hits → Step 6 request-changes, stop. If checks are pending or missing, wait and report `waiting-checks`; do not request changes for CI that has not run yet. If the branch is merely `BEHIND`, update it from `main` via `gh pr update-branch "$PR"` when the branch is repo-owned or maintainer edits are enabled; only request changes if that update fails or creates conflicts.
-     - Step 4 bot-loop:
-       - All 3 bots (`gemini-code-assist[bot]`, `copilot-pull-request-reviewer[bot]`, `coderabbitai[bot]`) must have `reviewed_current_head == true` against HEAD_SHA, or be marked `unavailable` because the app/reviewer cannot be requested in this repo.
-       - If any bot is still catching up and hasn't been kicked against HEAD_SHA → kick once, move on, return `waiting-bots` for this PR this run.
-       - If all reviewed & clean → Step 5 approve + auto-merge.
-       - If all reviewed & has findings → classify (blocker vs. nit). Blocker → Step 6 request-changes. Non-blocking nits get one acknowledgement comment and do not force another review cycle; exit loop to Step 5 when all other gates are green.
-     - Step 7 human threads:
-       - Human replied in last 14 days and we haven't responded → reply substantively, return `waiting-human`.
-       - Human hasn't replied in ≥ 14 days AND we already replied → add a stale warning label/comment first, then autonomously resolve per Step 7 rules only if the thread remains unanswered.
-   - Never merge if any of the 3 bots hasn't reviewed current HEAD (unless that bot is unavailable in the org). Never merge while GitHub reports `DIRTY`, `BLOCKED`, `BEHIND`, or `UNSTABLE`. Never exceed 3 bot-kick iterations per PR per daily run.
-
-7. **Issue triage**
-   - `gh issue list --state open --limit 50`
-   - `gh pr list --state open --limit 50`
-   - Look for:
-     - Missing labels (apply `bug`, `enhancement`, `question` as appropriate).
-     - Stale-candidate issues with no activity in 90 days (let the `stale.yml` workflow handle closure; don't close manually unless the issue is clearly invalid).
-     - Duplicates to mark with `duplicate`.
-     - PR blockers worth tracking in the report: merge conflicts, missing CI, stale bot reviews, unresolved human asks, guarded public API changes, dependency/SDK changes, or breaking commits.
-   - Do not add noisy duplicate comments when a current-head review already states the blocker.
-
-8. **Cleanup**
-   - Delete clean temporary worktrees created by this run with `git worktree remove <path>`.
-   - If a temporary worktree contains uncommitted diagnostics or logs that must be preserved, keep it and include the absolute path in the final report.
-
-## Output
-
-Write a short report:
-- Dependencies: N outdated (list)
-- Repo freshness: origin/main SHA, local checkout clean/dirty/behind, Flutter/Dart version
-- Analyze: pass/fail
-- Format: pass/fail
-- Publish dry-run: pass/fail
-- Tests: N passed / M failed (coverage %)
-- PRs:
-  - `#<N> <author> <merged|requested-changes|waiting-bots|waiting-human|skipped(draft|bot-bypass-failed)> [iter=<K>] [checks=<status>]`
-- Issues touched: list PR numbers / issue numbers
-
-Make code changes through scoped branches and PRs when the task is clear and safe. If something is ambiguous, breaking, or blocked by external service configuration, file/update an issue and mention it in the report.
-
----
-
-## Weekly / monthly
-
-The schedule skill runs these on different cadences — see `.claude/guides/05-deployment.md`. They include:
-
-- **Weekly**: dependency update PR (which goes through the same 3-bot auto-merge loop above), CHANGELOG tidy, breaking/release-readiness review.
-- **Monthly**: Flutter stable compatibility check against latest stable, deprecated-API sweep.
+Weekly runs may prepare grouped compatible dependency upgrades and changelog
+maintenance. Monthly runs verify the newest stable Flutter and sweep deprecated
+APIs. Both use the same verification and no-implicit-merge rules.

--- a/.claude/commands/resolve-issue.md
+++ b/.claude/commands/resolve-issue.md
@@ -1,0 +1,29 @@
+---
+name: resolve-issue
+description: Investigate and resolve a flutter_calendar_carousel GitHub issue with reproduction evidence, focused fixes, regression tests, and verified PR delivery when authorized.
+---
+
+# /resolve-issue
+
+Argument: issue number or URL.
+
+## Procedure
+
+1. Fetch the issue body, labels, timeline, linked PRs, and relevant closed issues
+   or releases. Confirm whether the report is reproducible on current `main` and
+   the exact current stable Flutter SDK.
+2. Classify it as reproducible, already fixed, duplicate, external configuration,
+   Flutter/platform limitation, question, or needs reporter evidence.
+3. For a reproducible issue, add a focused failing regression test first when
+   practical, implement the smallest compatible fix, and run the relevant
+   matrix from `.claude/commands/verify-all.md`.
+4. For an already-fixed or non-code issue, collect concrete commit, version,
+   workflow, platform, or documentation evidence. Do not manufacture a code
+   change merely to close an issue.
+5. Commit, push, and create a PR only when authorized. Link the issue in the PR
+   body and state whether it should close automatically or remain open for an
+   external verification such as pub.dev publishing.
+6. Post or close an issue only when external GitHub writes were authorized.
+
+Use English publicly. Preserve public API compatibility and do not conflate a
+local workflow fix with confirmation that an external release has published.

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,183 +1,60 @@
 ---
 name: review-pr
-description: Review a GitHub PR under the 3-bot loop (Gemini + Copilot + CodeRabbit). Assign bots on open, watch their reviews, re-kick until quiet, then auto-merge. Human threads get 14-day patience before autonomous resolution. No human approval on clean PRs.
+description: Fix pull-request feedback, verify the exact current head, and poll every five minutes until two consecutive clean snapshots. Never merge unless separately requested.
 ---
 
 # /review-pr
 
-End state for every PR this skill touches:
+Argument: PR number or URL. If omitted, resolve the PR for the current branch.
 
-1. Copilot is a requested reviewer, or the request failed because that bot is
-   unavailable in this repository and the failure is logged.
-2. Gemini has posted at least one review against the current HEAD (triggered via `/gemini review for $HEAD_SHA` comment).
-3. CodeRabbit has posted a summary against the current HEAD (auto-triggered by its GitHub App on push), or CodeRabbit is unavailable in this repository and logged.
-4. No bot has actionable feedback outstanding against the current HEAD.
-5. No human thread is unanswered AND either the human has replied, or the thread is ≥ 14 days old, has received a stale warning, and we have resolved autonomously.
-6. All reported status checks are green. Missing or pending checks are a wait
-   state, not a change request.
+The complete algorithm is `.codex/skills/review-pr/SKILL.md`. Claude Code uses
+`.claude/skills/review-pr/SKILL.md`; Codex invokes `$review-pr`. Read the
+canonical skill completely before acting.
 
-Only when all six are true do we approve + auto-merge.
+## Project Checks
 
-Argument: PR number or URL (positional `$1`).
+Select checks from the changed paths. For dependency, Flutter, native example,
+release, publish, or broad workflow changes, run the complete matrix in
+`.claude/commands/verify-all.md` against the current stable Flutter SDK.
 
-## Step 0 — Prep the PR (first time we see it)
+At minimum, behavior changes need format, analysis, root tests, and a focused
+regression test. Example dependency or native changes also need example analysis,
+tests, Android debug build, and an iOS simulator build when Xcode is available.
+Workflow changes need YAML validation and a faithful local simulation of changed
+shell logic when possible.
 
-If Copilot is NOT yet a requested reviewer AND the PR is not authored by a bot:
+## Round Checklist
 
-```bash
-OWNER_REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
-PR="$1"
-HEAD_SHA=$(gh pr view "$PR" --json headRefOid --jq .headRefOid)
+1. Resolve repository, PR, actual base, editable head, and exact head SHA.
+2. Refresh full diff, checks, reviews, requested reviewers, top-level comments,
+   paginated inline comments, and GraphQL review threads.
+3. Auto-resolve only threads GitHub marks outdated.
+4. Validate every current finding. Fix valid findings now; add regression tests
+   where appropriate. Reply with evidence when a finding is invalid or already
+   fixed.
+5. Verify, commit, and push the coherent fix batch when authorized.
+6. Reply through the inline comment reply API with the plain commit hash, then
+   resolve the addressed thread.
+7. Re-request configured reviewers only when the head changed. If automation is
+   terminally unavailable, use one exact-head `$review-self` fallback pass.
+8. Poll again after 300 seconds through a real product wake-up. Finish only after
+   two clean snapshots separated by five minutes.
 
-gh pr edit "$PR" --add-reviewer "copilot-pull-request-reviewer[bot]" \
-  || echo '{"reviewers":["copilot-pull-request-reviewer[bot]"]}' | gh api -X POST "repos/$OWNER_REPO/pulls/$PR/requested_reviewers" --input -
+Pending checks or active reviewers are wait states. A clean snapshot requires
+all required checks terminal and successful or explicitly allowed to skip, no
+actionable thread, no pending configured reviewer, clean fallback coverage for
+unavailable reviewers, and a reread of the exact current-head diff.
 
-gh pr comment "$PR" --body "/gemini review for $HEAD_SHA"
+## Public Reply Rules
 
-# CodeRabbit: no manual action — configured via .coderabbit.yaml.
-```
+- Use English.
+- Reply to the exact inline comment, not a new general PR comment.
+- Write commit hashes as plain text so GitHub links them.
+- Never promise to fix a valid finding later.
+- Never dismiss feedback or weaken a gate to obtain green status.
+- Never merge from this command without separate explicit merge authority.
 
-If a bot request fails because the app/reviewer is unavailable in this repo
-(404/403/422 from the reviewer request path), log `unavailable` for that bot
-and skip waiting on it; do not block the PR on that bot.
+## Result
 
-## Step 1 — Fetch state
-
-```bash
-gh pr view "$PR" --json number,title,body,author,baseRefName,headRefName,isDraft,labels,mergeStateStatus,statusCheckRollup,reviewDecision,reviews,reviewRequests,comments,commits,headRefOid,updatedAt
-gh pr diff "$PR"
-gh pr checks "$PR" --watch=false
-```
-
-Extract: `HEAD_SHA`, checks map, all reviews (login/state/submitted_at/commit_id), and top-level comments from the `gh pr view` payload. Use direct REST calls only as a pagination fallback or when the `gh pr view` payload is missing required review/comment fields.
-Keep `OWNER_REPO`, `PR`, and `HEAD_SHA` in scope for the later bot kick and merge commands; recompute them before Step 4 if the workflow is split across shell invocations.
-
-## Step 2 — Short-circuit gates (block merge immediately)
-
-If any is true, jump to Step 6 — Request changes:
-
-- `isDraft == true`
-- Any completed check conclusion ∉ {SUCCESS, SKIPPED}
-- `baseRefName != main`
-- Any commit subject contains `!:` OR body contains `BREAKING CHANGE:`
-- **Project-specific guarded paths (flutter_calendar_carousel):**
-  - `lib/flutter_calendar_carousel.dart` — any rename/removal of an exported class, typedef, or public field on `CalendarCarousel<T>` → human review (public API surface)
-  - `lib/classes/**` — any removal or rename in `EventInterface`, `Event`, `EventList`, `MarkedDate`, `MultipleMarkedDates` (public data types) → human review
-  - `lib/src/default_styles.dart` — any change to default `TextStyle` / `Color` values (globally visible to every downstream user) → human review
-  - `pubspec.yaml` — any new non-dev dependency that isn't from a pub.dev verified publisher → human review; any change to `environment: sdk:` constraint → human review; any manual `version:` bump (release workflow owns this) → human review; any addition or modification of `dependency_overrides` → human review
-  - `analysis_options.yaml` — disabling lint rules or removing `flutter_lints` → human review
-  - `.github/workflows/release.yml`, `.github/workflows/publish.yml`, `.github/workflows/auto-release.yml` — any edit → human review (tag-format, OIDC, and release logic are load-bearing)
-  - `.github/workflows/security-*.yml` — removed/weakened
-- Title or any commit contains `revert`
-- Test files under `test/` deleted without same-PR replacement
-- `mergeStateStatus` ∈ {DIRTY, BLOCKED}
-- `mergeStateStatus == BEHIND` after one attempted update from `main` using `gh pr update-branch "$PR"` when the branch is repo-owned or maintainer edits are enabled.
-
-If checks are absent, queued, pending, or in progress, return `waiting-checks`
-for this run. Do not request changes for checks that have not completed.
-
-## Step 3 — Bot bypass (PRs authored by bots)
-
-If `author.login` matches `dependabot[bot]`, `renovate[bot]`, `github-actions[bot]`, or ends in `[bot]`:
-
-- Verify all checks green.
-- `gh pr review "$PR" --approve --body "Automated bot PR — auto-merging." || true`
-- `gh pr merge "$PR" --auto --squash --delete-branch`
-- Skip the 3-bot loop — CI is the gate for bot PRs.
-
-## Step 4 — Bot review loop (core contract)
-
-Bot logins:
-
-| Bot | Login | Re-kick |
-|---|---|---|
-| Gemini | `gemini-code-assist[bot]` | `gh pr comment "$PR" --body "/gemini review for $HEAD_SHA"` |
-| Copilot | review author `copilot-pull-request-reviewer[bot]`; reviewer login `copilot-pull-request-reviewer[bot]` | `echo '{"reviewers":["copilot-pull-request-reviewer[bot]"]}' \| gh api -X POST "repos/$OWNER_REPO/pulls/$PR/requested_reviewers" --input -` |
-| CodeRabbit | `coderabbitai[bot]` | nothing — re-runs on push |
-
-### 4a. Classify each bot against current HEAD
-
-For each bot:
-
-- `reviewed_current_head`: true when the latest bot review has `commit_id == HEAD_SHA`. For bots that only leave top-level comments without commit IDs, count the response only when its body contains the `HEAD_SHA` or its 7-character prefix from the kick; otherwise return `waiting-bots`.
-- `has_findings`: true if the latest content contains `state == "CHANGES_REQUESTED"`, inline severity markers (🛑 / ⚠️ / `Critical` / `Major` / `Nit:`), an opening code fence whose info string is `suggestion`, or reviewer-authored TODO/FIXME text. Ignore TODO/FIXME when it appears only inside quoted code, diffs, or documentation examples.
-- `unavailable`: true if the bot's app or reviewer cannot be requested in this repo (kick returned 404/403/422).
-
-### 4b. Decision
-
-- All three `reviewed_current_head == true` AND no `has_findings` → **exit loop, go to Step 5**.
-- All three `reviewed_current_head == true` AND ≥1 has findings:
-  - Summarize per-bot findings in a single top-level comment `## Bot review pass N\n...`.
-  - Per finding:
-    - **Blocker** (security, correctness, API break) → add to Step 6 list, stop loop.
-    - **Non-blocker** (style, nit) → acknowledge in top-level comment; continue.
-  - If any blocker existed → Step 6 and stop.
-  - If no blockers → acknowledge the nits once in the pass summary and exit loop to Step 5 when all other gates are green. Do not keep re-kicking bots for non-blocking nits.
-- Any bot `reviewed_current_head == false` AND NOT `unavailable` → **wait**:
-  - If this bot hasn't been kicked against HEAD_SHA yet, kick once.
-  - Otherwise do nothing; return `waiting-bots`.
-- `unavailable` bots: ignore, don't block merge.
-
-### 4c. Never
-
-- Never write code changes from this skill. Fixes are for the PR author.
-- Never approve before §4b's exit condition.
-- Never force-push/amend/rebase.
-- Never kick a bot more than once per iteration.
-
-## Step 5 — Approve + auto-merge
-
-All preconditions must hold (§2 clean, §4 exit, no open human thread, all checks green, `mergeStateStatus` ∈ {CLEAN, HAS_HOOKS}):
-
-```bash
-gh pr review "$PR" --approve --body "All automated reviewers quiet; merging."
-gh pr merge "$PR" --auto --squash --delete-branch
-```
-
-Return `MERGED <sha>`.
-
-## Step 6 — Request changes
-
-```bash
-gh pr review "$PR" --request-changes --body "$(cat <<'EOF'
-Auto-review found blockers. Push a fix; next daily run will re-evaluate.
-
-<bullet list: file:line — issue — suggested fix>
-EOF
-)"
-```
-
-Put every requested change in the review body as concrete file/line guidance. Do not apply the author's code changes from this command, do not use inline comments, and do not merge.
-
-## Step 7 — Human conversations
-
-Scan for unresolved human threads (non-bot authors):
-
-- **< 14 days since human's latest message**: reply substantively, wait. Return `waiting-human`.
-- **≥ 14 days AND we already replied AND human hasn't responded**: add a stale warning label/comment and wait one more routine pass before autonomous resolution.
-- **Stale warning already posted AND human still hasn't responded**:
-  - Clear code change ask → request changes with the required edits in the review body + log "Auto-resolving after stale warning and no reply".
-  - Question we already answered → "Auto-closing thread after stale warning; our prior answer stands." Proceed to Step 5.
-  - Ambiguous → prefer request-changes over merge. Log the decision.
-
-## Step 8 — Return format
-
-```
-PR #<N> <author> <result> [iter=<K>] [waiting=<bots|human>] [checks=<status>]
-```
-
-Result ∈ merged | requested-changes | waiting-bots | waiting-checks | waiting-human | skipped(draft|bot-bypass-failed).
-
-## Hard rules
-
-1. Never merge until all 3 bots reviewed current HEAD (or marked unavailable).
-2. Never silence a bot by dismissing its review.
-3. Never exceed 3 kicks per bot per daily run.
-4. Never treat a human's question as answered by our previous reply unless > 14 days elapsed and a stale warning was already posted.
-5. Never skip §2 gates because bots approved.
-6. Never open a PR from this skill. The daily routine may open a PR before invoking this review loop; `/review-pr` itself only reviews an existing PR.
-7. Never re-request review from a bot that already reviewed clean — that's the exit condition.
-
-## Tuning knobs
-
-`REVIEW_LOOP_MAX_ITERS=3`, `REVIEW_HUMAN_AUTONOMY_DAYS=14`, `REVIEWER_{COPILOT,GEMINI,CODERABBIT}_LOGIN`.
+Report the PR URL, exact head SHA, checks, findings fixed or rebutted, threads
+resolved, reviewer availability/fallback, poll count, and clean count.

--- a/.claude/commands/verify-all.md
+++ b/.claude/commands/verify-all.md
@@ -1,0 +1,54 @@
+---
+name: verify-all
+description: Run the full flutter_calendar_carousel package, example consumer, native build, publishability, and repository consistency matrix.
+---
+
+# /verify-all
+
+Use the exact latest stable Flutter SDK when claiming latest compatibility.
+Record `flutter --version` and `dart --version` with the result.
+
+## Required Matrix
+
+```bash
+set -euo pipefail
+
+flutter pub get
+dart format --set-exit-if-changed .
+flutter analyze
+flutter test --coverage
+flutter pub outdated
+
+(
+  cd example
+  flutter pub get
+  flutter analyze
+  flutter test
+  flutter build apk --debug
+)
+
+flutter pub publish --dry-run
+git diff --check
+```
+
+When iOS project or dependency files changed and macOS/Xcode is available, also
+run an iOS simulator build from `example/`. When public web compatibility is in
+scope, build a minimal temporary Flutter web consumer that imports the package.
+Keep all temporary consumers outside the repository and remove them afterward.
+
+Validate changed GitHub workflow YAML. For release/publish shell changes, run a
+non-destructive simulation in a temporary worktree or copy so ignored and
+generated file behavior is exercised.
+
+## Dependency Interpretation
+
+Use `flutter pub outdated --json` when machine-readable classification helps.
+Update direct and dev dependencies to their latest compatible resolvable
+versions. Report transitive latest-only versions constrained by Flutter/Dart
+separately; do not force them with `dependency_overrides`.
+
+## Completion
+
+Fail on the first real error, preserve full failure output, and do not call the
+result regression-free when a required platform check was skipped. Report each
+command, SDK version, pass/fail result, and justified skip.

--- a/.claude/guides/05-deployment.md
+++ b/.claude/guides/05-deployment.md
@@ -1,124 +1,83 @@
-# 05 — Deployment (CI, Release, Publish, Daily Routine)
+# 05 — Deployment
 
-This guide describes how code moves from `main` to pub.dev.
+This guide describes the guarded path from `main` to pub.dev. A request to open
+or review a PR does not authorize any step in this release path.
 
-## Workflows at a glance
+## Workflows
 
 | Workflow | Trigger | Purpose |
 | --- | --- | --- |
-| `.github/workflows/ci.yml` | `push`/`pull_request` on `main` | pub get → analyze → format-check → test (+coverage). Gate for merges. |
-| `.github/workflows/auto-release.yml` | cron (Mondays 10:00 UTC) + `workflow_dispatch` | Decide bump (patch default, minor for `feat:`, skip on BREAKING), dispatch `release.yml`. |
-| `.github/workflows/release.yml` | `workflow_dispatch` (also dispatched by `auto-release.yml`) | Version bump, CHANGELOG regen, commit, tag `v{VERSION}`, GitHub Release. |
-| `.github/workflows/publish.yml` | tag push matching `v*` | Publish to pub.dev via OIDC (`dart pub publish --force`). Enabled; requires pub.dev-side OIDC setup. |
-| `.github/workflows/stale.yml` | scheduled | Close stale issues. |
+| `ci.yml` | relevant pushes/PRs to `main`, manual | Format, analyze, root/example tests, coverage, Android consumer build |
+| `auto-release.yml` | weekly/manual | Choose patch/minor or stop for a breaking release, then dispatch release |
+| `release.yml` | manual/auto-release dispatch | Validate, bump version, refresh example lock, changelog, commit, tag, GitHub Release |
+| `publish.yml` | `v*` tag | Authenticate with pub.dev OIDC, verify, and publish |
+| `stale.yml` | schedule | Manage inactive issues |
 
-## ci.yml — what it enforces
+CI path filters include the complete `example/**` tree so lockfile-only and
+native consumer changes cannot bypass verification.
 
-- Runs on Ubuntu, Flutter `stable`.
-- Path-filtered to `lib/**`, `test/**`, `pubspec.yaml`, `analysis_options.yaml`, and the workflow itself — no-op on README-only changes.
-- Concurrency group cancels in-flight runs on the same ref.
-- Steps: `flutter pub get` → `dart format --set-exit-if-changed .` → `flutter analyze` → `flutter test --coverage` → upload coverage to Codecov.
-- Must be green before merge. No manual bypass.
+## Release Workflow
 
-## auto-release.yml — how releases happen without you
+`release.yml` accepts `patch`, `minor`, `major`, `current`, or `rc-bump`, plus
+prerelease and GitHub Release flags. Validation runs package dependency install,
+format, analysis, tests, and publish dry-run.
 
-`auto-release.yml` runs on a weekly cron (Mondays 10:00 UTC). On each run it:
+For a new version the deploy job:
 
-1. Finds the most recent tag reachable from the release branch via `git describe --tags --abbrev=0`.
-2. If there are no commits since that tag → skip (nothing to release).
-3. Otherwise, inspects commit messages in the `<prev-tag>..HEAD` range:
-   - `BREAKING` or `!:` anywhere → **skip** and surface "human-dispatched major required".
-   - Any `feat:` commit → **minor**.
-   - Otherwise → **patch**.
-4. Dispatches `release.yml` with the chosen bump.
+1. Updates root `pubspec.yaml`.
+2. Runs `flutter pub get` in both the root and `example/`, which resolves the
+   path dependency in `example/pubspec.lock` to the new package version.
+3. Regenerates the changelog section.
+4. Stages `pubspec.yaml`, `CHANGELOG.md`, and `example/pubspec.lock` only. The
+   ignored root lockfile is intentionally not force-added.
+5. Commits, tags `v{VERSION}`, pushes, and optionally creates a GitHub Release.
 
-If you need an off-cycle cut (e.g. a targeted `major`), just run:
+Do not manually ship code that assumes a different tag format.
 
-```
-gh workflow run release.yml -f version=major -f prerelease=false -f create_release=true
-```
+## pub.dev Trusted Publishing
 
-`auto-release.yml` and `release.yml` share a concurrency lock — only one release can be in flight at a time.
+`publish.yml` runs for `v*` tags with `id-token: write` and environment
+`pub-dev`. It checks out the tag, runs pinned `dart-lang/setup-dart` first to
+provision the short-lived OIDC credential, installs stable Flutter, then runs
+format, analysis, tests, publish dry-run, and `dart pub publish --force`.
 
-## release.yml — how to cut a release manually
+One-time pub.dev package configuration:
 
-Dispatched from the Actions tab (or via `gh workflow run release.yml`). This is the workflow `auto-release.yml` calls under the hood.
+1. Enable GitHub Actions automated publishing for
+   `hyochan/flutter_calendar_carousel`.
+2. Set tag pattern to `v{{version}}`.
+3. Set the required environment to `pub-dev`.
 
-Inputs:
+The workflow fix can be verified locally, but successful publication is only
+confirmed by a completed tag workflow and the new version appearing on pub.dev.
+If a version is already published, make a new version; never move or recreate a
+published release tag.
 
-- `version`: `patch` | `minor` | `major` | `current` | `rc-bump`
-- `prerelease`: `true` | `false` — wraps the version with `-rc.1` when bumping.
-- `create_release`: `true` | `false` — whether to also create a GitHub Release.
+## Routine Maintenance
 
-Job graph:
+`.claude/commands/daily-routine.md` is the canonical sweep. It checks fresh
+`origin/main`, direct/dev dependency drift, current stable Flutter compatibility,
+root and example verification, publishing readiness, issues, PRs, and failed
+workflows. Maintenance PRs enter `.claude/commands/review-pr.md`; they are never
+implicitly merged.
 
-1. **validate** — `flutter pub get`, `flutter analyze`, `dart format --set-exit-if-changed .`, `flutter test`.
-2. **deploy** (needs `validate`) —
-   1. Parse current version from `pubspec.yaml`.
-   2. Compute new version based on the input.
-   3. Write new version back to `pubspec.yaml`.
-   4. Regenerate `CHANGELOG.md` (PR titles from `git log <prev-tag>..HEAD`).
-   5. Commit, tag `v{VERSION}`, push.
-   6. If `create_release=true`, `gh release create v{VERSION}` with the CHANGELOG slice as body.
+## Required Configuration
 
-Tag format is **`v{VERSION}`** (e.g. `v2.5.5`, `v2.6.0-rc.1`). Do not ship any code that assumes another format — `publish.yml`'s trigger matcher depends on it.
+- `CODECOV_TOKEN`: optional coverage upload secret. Missing token skips upload.
+- `DEPENDENCY_UPDATE_PAT`: optional release checkout token used when a bot push
+  must trigger downstream workflows.
+- pub.dev trusted-publishing link: package-side configuration, not a repository
+  secret.
+- Branch protection: require the repository's CI and normal review policy.
 
-## publish.yml — pub.dev via OIDC
+## Failure Handling
 
-Triggered by `push: tags: ['v*']`. Runs:
-
-1. Checkout.
-2. `subosito/flutter-action@v2` with stable Flutter.
-3. `flutter pub get`.
-4. `flutter pub publish --dry-run` (sanity gate).
-5. Request OIDC token.
-6. `dart pub publish --force`.
-
-### OIDC bring-up checklist (one-time)
-
-1. On pub.dev → package admin → "Automated publishing" → enable GitHub Actions publishing.
-2. Set repository to `hyochan/flutter_calendar_carousel`.
-3. Set tag pattern to `v*`.
-4. Set allowed environment (blank is fine for this repo; optional `pub-dev` environment adds a review gate).
-5. Confirm the workflow has `permissions: { id-token: write }` at job level.
-
-`publish.yml` is enabled and will run on every `v*` tag push. If pub.dev OIDC is not yet configured on the package's admin page, the first auto-release will fail at the `dart pub publish --force` step with an auth error — that is the signal to finish the pub.dev-side setup. Until then, the tag + GitHub Release will still be created; only the pub.dev upload step will fail.
-
-## Daily routine (Cowork schedule skill)
-
-A single consolidated scheduled task, `flutter-calendar-carousel-daily`, runs every weekday morning. It always does the daily block, and branches into the weekly block on Mondays and the monthly block on the 1st of the month. The routine definition is in `.claude/commands/daily-routine.md`.
-
-**Daily block (every weekday)**
-1. Repository freshness — fetch `origin/main` and run against latest remote state; use a clean temporary worktree when the mounted checkout has local changes, then remove that worktree before exit or report the retained path.
-2. Autonomous task queue — split actionable maintenance into small branches/PRs: failed sweep fixes, dependency/Flutter drift, CI/release/publish failures, automation gaps, and base-repo fixes for PR blockers.
-3. Dependency check — `flutter pub outdated` and `flutter pub outdated --json`, split into direct/dev upgradable, direct/dev blocked, and transitive latest-only updates.
-4. Code quality — `flutter analyze` + `dart format --set-exit-if-changed .` + `flutter pub publish --dry-run`.
-5. Tests — `flutter test --coverage`.
-6. Issue/PR triage — label issues, mark clear duplicates, and report PR blockers such as missing CI, merge conflicts, guarded public API changes, SDK/dependency changes, or breaking commits.
-7. PR lifecycle — for bot- or maintainer-authored maintenance PRs, monitor CI and bot reviews, push follow-up fixes when needed, approve/enable auto-merge only when all gates are green, and never push directly to `main`.
-
-**Weekly block (Mondays only)**
-8. Dependency update PR — if any direct/dev dependency has a safe compatible/resolvable update, open a PR bumping it, then run analyze, format, tests with coverage, and publish dry-run.
-9. Blocked dependency tracking — if a package needs an SDK constraint change, unverified publisher dependency, or likely breaking major upgrade, create/update `maintenance: dependency upgrade blocked` instead of auto-merging it.
-10. CHANGELOG tidy — surface any merged PRs since the last release so they don't get lost.
-11. Breaking/release readiness — report commits since tag, `feat:`/`BREAKING`/`!:` commits, guarded public API path changes, and publish dry-run status.
-
-**Monthly block (1st of month only)**
-12. Flutter SDK compatibility — switch to/upgrade latest Flutter stable, then run analyze, format, tests with coverage, and publish dry-run.
-13. Deprecated-API sweep — grep for `@Deprecated` usage that's been shipped for ≥1 minor release and propose removal for the next major.
-
-The schedule entry itself lives in Cowork, not in this repo. Earlier iterations of this setup used three separate tasks (daily/weekly/monthly); those have been consolidated into one to reduce noise.
-
-## Repo-specific knobs & secrets
-
-- **`CODECOV_TOKEN`** — GitHub Actions secret used by `ci.yml` for coverage upload.
-- **`DEPENDENCY_UPDATE_PAT`** — (optional) personal access token used by the weekly dependency-update PR. Pushes made with the default `GITHUB_TOKEN` do not trigger new workflow runs, so this PAT ensures CI runs on auto-generated dependency PRs. If missing, CI for those PRs will not run automatically.
-- **pub.dev OIDC link** — not a secret; configured on the pub.dev side (see above).
-- **Repository `main` branch protection** — require `ci.yml` green + at least one review.
-
-## When things go wrong
-
-- **CI red on `main`** — revert the offending commit, file an issue, land the fix in a follow-up PR.
-- **Release workflow failed mid-deploy** — inspect what got committed/tagged. If the tag went out but `publish.yml` didn't fire (or was disabled), you may need to re-push the tag. If `publish.yml` fired and pub.dev rejected, fix the cause and ship a new patch version.
-- **pub.dev publish rejected for version already published** — version conflict. Bump to the next patch and re-release.
-- **Wrong version in `pubspec.yaml` committed by hand** — revert; the workflow owns version bumps.
+- Red `main`: reproduce and land a focused fix PR; avoid destructive tag/history
+  edits.
+- Release failure: identify whether a commit or tag was already pushed before
+  retrying. Never overwrite a published tag.
+- Publish authentication failure: verify pub.dev repository, tag pattern,
+  environment, OIDC permission, and setup-dart step; release a new patch after
+  correcting it.
+- Stale example lock version: rerun root `flutter pub get` after the root version
+  bump and stage `example/pubspec.lock`.

--- a/.claude/skills/flutter-calendar-carousel-workflows/SKILL.md
+++ b/.claude/skills/flutter-calendar-carousel-workflows/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: flutter-calendar-carousel-workflows
+description: Use for flutter_calendar_carousel repository work that should follow its shared workflows for issue resolution, dependency and Flutter upgrades, verification, commits, pull requests, releases, and PR monitoring.
+---
+
+# Flutter Calendar Carousel Workflows (Claude Code)
+
+The canonical repository rules live in `AGENTS.md`; the canonical workflow
+router lives in `.codex/skills/flutter-calendar-carousel-workflows/SKILL.md`.
+Read and follow both completely.
+
+When the router selects a `.claude/commands/*.md` file, read that command before
+acting. Where a canonical skill requires a product wake-up or recurring monitor,
+use Claude's real scheduled wake-up mechanism. Never substitute `sleep`, a shell
+loop, `nohup`, or an abandoned background process.

--- a/.claude/skills/rebase-main/SKILL.md
+++ b/.claude/skills/rebase-main/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: rebase-main
+description: Safely update local main and rebase the current flutter_calendar_carousel branch without losing staged, unstaged, untracked, or ignored work.
+---
+
+# Rebase Main (Claude Code)
+
+Read and follow `.codex/skills/rebase-main/SKILL.md` completely, including its
+working-tree snapshot, stash recovery point, ignored-file collision guards,
+three-way conflict handling, restoration verification, and no-implicit-push
+rule.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: review-pr
+description: Inspect and finish flutter_calendar_carousel pull requests by fixing valid review findings, resolving threads, diagnosing CI, and polling every five minutes until the exact head is clean.
+---
+
+# Review PR (Claude Code)
+
+Read and follow `.codex/skills/review-pr/SKILL.md` completely. Its authority
+rules, current-head evidence, fix/reply/resolve procedure, reviewer fallback,
+five-minute polling contract, two-clean-snapshot gate, and no-implicit-merge rule
+are canonical for Claude Code too.
+
+Use `.claude/commands/review-pr.md` as the command entry point. For unavailable
+reviewers, invoke the local `review-self` skill for exactly one non-polling pass.

--- a/.claude/skills/review-self/SKILL.md
+++ b/.claude/skills/review-self/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: review-self
+description: Independently review and improve current flutter_calendar_carousel work, fix actionable gaps, rerun verification, and recheck every five minutes until stable.
+---
+
+# Review Self (Claude Code)
+
+Read and follow `.codex/skills/review-self/SKILL.md` completely. Use Claude's
+real scheduled wake-up mechanism for five-minute confirmations. If none exists,
+finish the immediate round and report the limitation; never emulate recurrence
+with a shell process.
+
+When invoked as the `review-pr` fallback, run exactly one complete round and do
+not request reviewers, handle review threads, or schedule another poll.

--- a/.codex/skills/flutter-calendar-carousel-workflows/SKILL.md
+++ b/.codex/skills/flutter-calendar-carousel-workflows/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: flutter-calendar-carousel-workflows
+description: Use for flutter_calendar_carousel repository work that should follow its shared workflows for issue resolution, dependency and Flutter upgrades, full verification, commits, pushes, pull requests, releases, PR feedback, five-minute review monitoring, and project conventions from AGENTS.md.
+---
+
+# Flutter Calendar Carousel Workflows
+
+Route natural-language requests through the repository's canonical rules and
+command entry points.
+
+## Source Of Truth
+
+1. Read `AGENTS.md` before changing the repository.
+2. Read only the matching `.claude/commands/*.md` workflow below.
+3. Apply this skill's cross-workflow safeguards when command prose is concise.
+4. For `review-pr`, `review-self`, or `rebase-main`, use the matching specialized
+   `.codex/skills/<name>/SKILL.md` as the canonical procedure.
+
+## Command Mapping
+
+- PR review, feedback, checks, or monitoring → `.claude/commands/review-pr.md`
+  and `$review-pr`
+- Self-review or final implementation audit → `$review-self`
+- Issue investigation and resolution → `.claude/commands/resolve-issue.md`
+- Full repository verification → `.claude/commands/verify-all.md`
+- Branch, commit, push, or PR creation → `.claude/commands/commit.md`
+- Daily repository maintenance → `.claude/commands/daily-routine.md`
+- Updating a branch from `main` → `$rebase-main`
+- Release or publishing work → `.claude/guides/05-deployment.md`
+
+Read the selected file completely before acting. Do not load every workflow by
+default.
+
+## Shared Safeguards
+
+- Preserve the authority of the user's request. Inspection does not authorize a
+  commit; commit does not authorize a push; push does not authorize a PR; a PR
+  does not authorize merge or release.
+- Public GitHub communication and commit messages must be in English.
+- Record initial Git state and preserve unrelated staged, unstaged, untracked,
+  and ignored files.
+- Prefer issue reproduction and regression tests over speculative fixes.
+- Use the exact latest stable Flutter SDK for current-compatibility claims.
+- Run direct and consumer checks after dependency or native-toolchain changes.
+- Do not edit another contributor's branch without explicit permission.
+- Do not treat unavailable external review automation as success; cover it with
+  one `$review-self` pass for the exact current head.
+- Do not merge, tag, publish, or deploy unless explicitly requested.
+
+## GitHub Review Threads
+
+Fetch PR metadata, checks, reviews, inline comments, top-level comments, and
+GraphQL review threads. Classify each finding against the current diff. Fix
+valid findings in a coherent batch, reply to the exact inline comment with a
+plain commit hash, and resolve only after the response is complete. Use
+evidence-backed replies for invalid or already-fixed findings.
+
+## Completion
+
+Report the resulting branch/PR, checks run, issue or review disposition, and any
+external blocker. Do not call work regression-free unless the required matrix
+passed on the relevant Flutter SDK and PR head.

--- a/.codex/skills/flutter-calendar-carousel-workflows/agents/openai.yaml
+++ b/.codex/skills/flutter-calendar-carousel-workflows/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Flutter Calendar Carousel Workflows"
+  short_description: "Run guarded Flutter package workflows"
+  default_prompt: "Use $flutter-calendar-carousel-workflows to complete this repository task with its checks and release safeguards."

--- a/.codex/skills/rebase-main/SKILL.md
+++ b/.codex/skills/rebase-main/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: rebase-main
+description: Safely update local main from origin/main, rebase the current flutter_calendar_carousel work branch, resolve conflicts without losing staged, unstaged, untracked, ignored, or generated work, and restore the original working-tree state. Use when asked to pull main, rebase onto main, update a branch, or fix a stuck rebase.
+---
+
+# Rebase Main
+
+Update `main`, rebase the current work branch, and preserve all local work. Do
+not commit or push unless separately authorized.
+
+## Establish And Safeguard
+
+1. Read `AGENTS.md`.
+2. Record branch, HEAD, upstream, worktrees, in-progress Git operations, staged,
+   unstaged, untracked, and relevant ignored files with content fingerprints.
+3. Stop if detached, currently on `main`, another operation is active, or `main`
+   is checked out elsewhere and cannot be updated safely.
+4. Default to `origin/main`; derive another target only from repository evidence.
+5. If dirty, create one named stash with `--include-untracked`, never `--all`.
+   Confirm the tracked and untracked worktree is clean. Preserve ignored secrets
+   and environment files in place.
+
+The stash is a recovery point. Do not drop it until restoration is exact.
+
+## Update And Rebase
+
+1. Fetch `origin main`.
+2. Before switching, verify no recorded ignored/local path collides with a path
+   tracked by the destination. Use `git checkout --no-overwrite-ignore` for
+   guarded transitions.
+3. Check out `main` and run `git merge --ff-only origin/main`. Stop on divergence;
+   never reset or create a merge commit to conceal it.
+4. Confirm local `main` and `origin/main` are identical.
+5. Check out the recorded work branch with the same collision guard.
+6. Run `git rebase origin/main`.
+7. Resolve each conflict by inspecting base, new-main, and work-branch intent.
+   Preserve compatible changes and regenerate derived files through their tools.
+   Never apply blanket ours/theirs resolution.
+
+Never use `git reset --hard`, `git checkout --`, `git clean`, or destructive
+recovery shortcuts.
+
+## Restore And Verify
+
+1. Apply the named stash with its index.
+2. Resolve restoration conflicts carefully. Keep the stash while any mismatch
+   remains.
+3. Compare staged, unstaged, untracked, and ignored fingerprints to the initial
+   snapshot.
+4. Drop only the named stash after exact restoration.
+5. Run `git status`, `git diff --check`, and affected lightweight checks.
+6. Report old/new main and branch heads plus restored working-tree state.
+
+If the work branch was published, explain that rewritten history needs a later
+`git push --force-with-lease`; do not perform it without explicit authorization.

--- a/.codex/skills/rebase-main/agents/openai.yaml
+++ b/.codex/skills/rebase-main/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Rebase Main"
+  short_description: "Safely rebase a work branch onto main"
+  default_prompt: "Use $rebase-main to update local main and safely rebase the current branch onto it."

--- a/.codex/skills/review-pr/SKILL.md
+++ b/.codex/skills/review-pr/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: review-pr
+description: Inspect and finish flutter_calendar_carousel pull requests by fixing valid review findings, replying and resolving threads, diagnosing CI, using review-self when automation is unavailable, and polling at five-minute intervals until the exact head is clean. Use for PR review, review feedback, CI failures, reviewer monitoring, or requests to keep reviewing until no actionable feedback remains.
+---
+
+# Review Pull Request
+
+Own one PR review loop. Fix valid findings now, verify the resulting head, and
+stop at a clean PR unless the user separately authorized merging.
+
+## Authority And Target
+
+- Read `AGENTS.md` and `.claude/commands/review-pr.md` completely.
+- Resolve a supplied number or URL. Otherwise use the PR for the current branch.
+- Confirm repository, base branch, head branch, exact head SHA, author, draft
+  state, and whether the branch can be edited safely.
+- Existing authorization to commit, push, create a PR, or reply to reviews is
+  preserved. Review authorization alone never grants merge or release authority.
+- Record the initial working tree and preserve unrelated changes.
+
+## Fetch The Complete Current State
+
+For every round, refresh:
+
+- PR metadata, full base-to-head diff, commits, and merge state;
+- check runs and status rollup for the exact head SHA;
+- submitted reviews, requested reviewers, and top-level comments;
+- paginated inline review comments;
+- GraphQL review threads with resolution and outdated state.
+
+Do not infer clean state from `reviewDecision` alone. Do not reuse review or CI
+evidence from an older head.
+
+Auto-resolve only unresolved threads GitHub marks outdated. Do not resolve a
+current thread merely because the author already replied.
+
+## Classify And Act
+
+For each unresolved current finding:
+
+1. Read the cited code and surrounding tests or workflow.
+2. Classify it as valid, invalid, already fixed, obsolete, or requiring a user
+   decision.
+3. Fix every valid in-scope correctness, compatibility, CI, documentation, or
+   regression gap in the current PR. Do not defer a real finding as follow-up.
+4. Add or strengthen a focused regression test when behavior changed.
+5. Run the verification required by the changed paths.
+
+After one coherent fix batch:
+
+1. Commit and push when already authorized.
+2. Reply directly to each inline comment using its reply endpoint. Mention the
+   plain commit hash without backticks and summarize the fix or evidence.
+3. Resolve the thread after the pushed fix or evidence-backed reply fully
+   addresses it.
+4. Re-request only reviewers that are configured for this repository and need a
+   new pass on the new head. Do not fabricate a three-bot requirement.
+
+All public replies must be concise English. Never hide a failed check, dismiss a
+review, or weaken a gate.
+
+## Verification Matrix
+
+Use touched-path checks while iterating. For dependency, Flutter SDK, native
+example, release, publish, or broad workflow changes, run:
+
+```bash
+flutter pub get
+dart format --set-exit-if-changed .
+flutter analyze
+flutter test --coverage
+(cd example && flutter pub get && flutter analyze && flutter test)
+(cd example && flutter build apk --debug)
+flutter pub publish --dry-run
+git diff --check
+```
+
+Build the iOS example for a simulator when iOS files changed and Xcode is
+available. Validate changed workflow YAML. Prefer current stable Flutter for
+compatibility claims.
+
+## Reviewer Fallback
+
+External review automation is optional coverage, not a completion dependency.
+A reviewer is unavailable for the current head when it returns a terminal
+quota, billing, permission, size, or service failure, or when two polling rounds
+after a request show neither a review nor a requested/in-progress state.
+
+When any configured reviewer is unavailable, run exactly one complete
+`$review-self` round against the actual base and head. Pass the requirements,
+changed paths, checks, and current commit/push authority. The fallback must not
+request reviewers or start its own polling loop. Cache clean fallback coverage
+by reviewer failure set and head SHA; invalidate it after any head change.
+
+## Five-Minute Polling Contract
+
+- Run the first review round immediately.
+- Use the product's recurring monitor or wake-up mechanism to re-enter
+  `$review-pr` 300 seconds after each non-terminal round. Never emulate this
+  with `sleep`, a shell loop, `nohup`, or an abandoned process.
+- Carry the PR number, base, exact head SHA, seen thread/check/review IDs, poll
+  count, clean count, fallback coverage, start time, and fix-attempt fingerprints.
+- Pending CI or active reviewers are neither clean nor failed. Poll without
+  rerunning expensive unchanged local checks.
+- A snapshot is clean only when the exact head has terminal successful or
+  allowed-skipped checks, no actionable unresolved feedback, no pending
+  configured reviewers, clean fallback coverage for unavailable reviewers, and
+  the final diff has been reread.
+- Finish after two consecutive clean snapshots separated by at least five
+  minutes. Reset the clean count on any head or material-state change.
+- If no real recurring mechanism exists, complete the current round and report
+  that automatic re-entry could not be scheduled. Do not claim it was scheduled.
+
+## Stop Conditions
+
+Stop and report exact evidence when two clean snapshots establish stability; the
+user redirects the task; the PR closes or changes incompatibly; a fix needs new
+authority or a product decision; the same finding survives two fix attempts; the
+same external/tool failure blocks three rounds; or only unchanged pending state
+remains after twelve polls. Never label a blocked or interrupted PR clean.
+
+Do not merge the PR unless the user explicitly asks for merge after these gates.

--- a/.codex/skills/review-pr/agents/openai.yaml
+++ b/.codex/skills/review-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Review PR"
+  short_description: "Fix PR feedback and confirm a clean head"
+  default_prompt: "Use $review-pr to address feedback and recheck this pull request every five minutes until stable."

--- a/.codex/skills/review-self/SKILL.md
+++ b/.codex/skills/review-self/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: review-self
+description: Independently review and improve the current flutter_calendar_carousel implementation, working-tree changes, commit range, or pull request; fix actionable in-scope gaps; rerun relevant verification; and recheck at five-minute intervals until stable. Use for self-review, final verification, implementation audits, or fallback coverage when an external PR reviewer is unavailable.
+---
+
+# Review Self
+
+Review the current work independently, fix validated gaps, and confirm stability.
+
+## Preserve Scope And Authority
+
+- Read `AGENTS.md` and reconstruct the requested outcome and acceptance criteria.
+- Review a supplied PR, range, or path; otherwise use the current branch plus all
+  staged, unstaged, and untracked changes against its actual merge base.
+- Record initial Git state and preserve unrelated work.
+- Do not commit, push, create or edit a PR, post comments, merge, or release
+  unless the original request already authorized that action.
+- Stop for a material product choice, irreversible action, or scope expansion.
+
+## One Complete Round
+
+1. Resnapshot the full target from disk. Do not review only the latest commit.
+2. Read requirements, surrounding implementation, tests, docs, relevant issues,
+   and current CI/review evidence.
+3. Review for requirement completeness, API compatibility, date/time edge cases,
+   rendering and gesture behavior, state transitions, error paths, platform and
+   Flutter compatibility, dependency safety, tests, documentation, examples,
+   release correctness, and security.
+4. Validate every finding against current code. Reject taste-only churn,
+   duplicates, and unrelated improvements.
+5. Fix all validated in-scope findings in one coherent batch. Regenerate native
+   or lock files through their owning tools.
+6. Reread the final diff and run the checks required by `AGENTS.md` and changed
+   paths. Do not repeat an expensive check when its inputs are unchanged.
+7. Commit and push only when authorized, staging only the current batch.
+
+Use `$flutter-calendar-carousel-workflows` to load only the needed detailed
+command. For a risky cross-cutting change use `.claude/commands/verify-all.md`.
+For GitHub issue work use `.claude/commands/resolve-issue.md`.
+
+## PR Fallback Mode
+
+When `$review-pr` invokes this skill because an external reviewer is unavailable:
+
+- Run exactly one complete round against the supplied base, head SHA,
+  requirements, and changed paths.
+- Preserve the caller's commit, push, and reply authority.
+- Do not re-enter `$review-pr`, request reviewers, handle trigger comments, or
+  schedule another poll.
+- Return head and working-tree fingerprints, findings and fixes, checks run, and
+  a clean or blocked result. Coverage is valid only for that exact head.
+
+## Five-Minute Confirmation
+
+- Run immediately, then use a real product recurring monitor or wake-up to
+  re-enter `$review-self` after 300 seconds.
+- Do not use `sleep`, a shell loop, `nohup`, or a background process.
+- Carry goal, target/base, head/tree fingerprints, working-tree fingerprint,
+  feedback and check IDs, findings/fix attempts, poll count, clean count, and
+  existing authority outside tracked repository files.
+- A round is clean only when no actionable finding remains, required checks pass,
+  required PR state is terminal and successful, and the resulting diff has been
+  reread.
+- Finish after two consecutive clean snapshots separated by five minutes. Reset
+  on any material change. If explicitly asked for one pass or invoked in PR
+  fallback mode, do not schedule the confirmation.
+- If no recurring mechanism is available, report that limitation after the
+  immediate round instead of pretending a future check was scheduled.
+
+Stop on success, user redirection, incompatible target change, missing authority,
+the same finding after two fix attempts, the same blocking tool failure for three
+rounds, or twelve unchanged pending polls. Report exact evidence and never call a
+blocked result clean.

--- a/.codex/skills/review-self/agents/openai.yaml
+++ b/.codex/skills/review-self/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Review Self"
+  short_description: "Review current work in five-minute loops"
+  default_prompt: "Use $review-self to review the current work, fix actionable findings, and recheck it every five minutes until stable."

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -43,7 +43,7 @@ jobs:
       reason: ${{ steps.decide.outputs.reason }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -103,7 +103,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Dispatch release
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,9 @@ on:
       - 'test/**'
       - 'pubspec.yaml'
       - 'pubspec.lock'
-      - 'example/pubspec.yaml'
-      - 'example/pubspec.lock'
+      - 'example/**'
       - 'analysis_options.yaml'
-      - '.github/workflows/ci.yml'
+      - '.github/workflows/**'
   pull_request:
     branches: [main]
     paths:
@@ -19,10 +18,9 @@ on:
       - 'test/**'
       - 'pubspec.yaml'
       - 'pubspec.lock'
-      - 'example/pubspec.yaml'
-      - 'example/pubspec.lock'
+      - 'example/**'
       - 'analysis_options.yaml'
-      - '.github/workflows/ci.yml'
+      - '.github/workflows/**'
   workflow_dispatch:
 
 concurrency:
@@ -37,16 +35,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: temurin
           java-version: '17'
 
       - name: Set up Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           channel: stable
           cache: true
@@ -66,11 +64,19 @@ jobs:
       - name: Run tests with coverage
         run: flutter test --coverage
 
+      - name: Run example tests
+        run: flutter test
+        working-directory: example
+
+      - name: Build Android example
+        run: flutter build apk --debug
+        working-directory: example
+
       - name: Upload coverage to Codecov
         if: ${{ env.CODECOV_TOKEN != '' }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: coverage/lcov.info

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,6 @@ on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch:
 
 permissions:
   id-token: write
@@ -34,10 +33,16 @@ jobs:
     environment: pub-dev
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # setup-dart requests the GitHub OIDC token and provisions the
+      # short-lived pub.dev credential. The Flutter SDK's dart binary shadows
+      # this action's binary below, but continues to use that credential.
+      - name: Set up pub.dev authentication
+        uses: dart-lang/setup-dart@7654d458321ee25acccccfdb86cd48bd95768ff1 # v1.8.0
 
       - name: Set up Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           channel: stable
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           channel: stable
           cache: true
@@ -72,7 +72,7 @@ jobs:
       tag: ${{ steps.bump.outputs.tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           token: ${{ secrets.DEPENDENCY_UPDATE_PAT || secrets.GITHUB_TOKEN }}
@@ -83,7 +83,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Set up Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           channel: stable
           cache: true
@@ -158,6 +158,12 @@ jobs:
           sed -i -E "s/^version: .*/version: ${NEW_VERSION}/" pubspec.yaml
           grep '^version:' pubspec.yaml
 
+      - name: Refresh example lockfile
+        if: inputs.version != 'current'
+        run: |
+          flutter pub get
+          (cd example && flutter pub get)
+
       - name: Regenerate CHANGELOG section
         env:
           NEW_VERSION: ${{ steps.bump.outputs.new_version }}
@@ -197,7 +203,7 @@ jobs:
           TAG: ${{ steps.bump.outputs.tag }}
         run: |
           set -euo pipefail
-          git add pubspec.yaml CHANGELOG.md
+          git add pubspec.yaml CHANGELOG.md example/pubspec.lock
           if git diff --cached --quiet; then
             echo "Nothing to commit (likely 'current' bump)."
           else

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v9
+    - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 90

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,90 @@
+# flutter_calendar_carousel Agent Guide
+
+This file is the repository-wide source of truth for Codex, Claude Code, and
+other coding agents. `CLAUDE.md` and `GEMINI.md` point here. Detailed reusable
+workflows live in `.codex/skills/`; Claude adapters live in `.claude/skills/`,
+and user-invoked command entry points live in `.claude/commands/`.
+
+## Repository Scope
+
+- Package: `flutter_calendar_carousel`
+- Default branch: `main`
+- Public package source: `lib/`
+- Regression tests: `test/`
+- Consumer smoke app: `example/`
+- CI and publishing: `.github/workflows/`
+
+## Non-Negotiables
+
+- Preserve public API compatibility unless the user explicitly authorizes a
+  breaking change. Treat exported types, constructor parameters, callbacks,
+  defaults, and date-selection behavior as public contracts.
+- Reproduce an issue and add a focused regression test before changing behavior
+  whenever practical.
+- Test the package as both a library and a real Flutter consumer. Example native
+  scaffolding must remain compatible with the current stable Flutter release.
+- Do not weaken analysis, tests, publishing validation, or release safeguards to
+  make a change pass.
+- Do not edit generated lockfiles or native project metadata by hand when the
+  corresponding Flutter, CocoaPods, or Gradle command can regenerate them.
+- Preserve unrelated user changes. Never use destructive Git recovery commands.
+- Do not commit directly to `main`, force-push, merge, publish, or release unless
+  the user explicitly authorized that action.
+
+## Verification
+
+Run the smallest sufficient set while iterating. Before a cross-cutting PR or a
+Flutter/dependency/tooling update, run the full matrix:
+
+```bash
+flutter pub get
+dart format --set-exit-if-changed .
+flutter analyze
+flutter test --coverage
+(cd example && flutter pub get && flutter analyze && flutter test)
+(cd example && flutter build apk --debug)
+flutter pub publish --dry-run
+git diff --check
+```
+
+Also build the iOS example for a simulator when iOS project or dependency files
+change and macOS/Xcode is available. For release or compatibility claims, use
+the exact latest stable Flutter SDK rather than relying only on a locally
+installed channel that may be behind.
+
+`flutter pub outdated` distinguishes actionable direct/dev upgrades from
+transitive packages constrained by the Flutter SDK. Do not force transitive
+versions through `dependency_overrides` merely to report everything as latest.
+
+## Issues And Pull Requests
+
+- Use English for public GitHub titles, bodies, reviews, replies, and commits.
+- Link fixes to issue numbers and preserve evidence for issues that are already
+  fixed, externally blocked, duplicates, or platform limitations.
+- Reply to inline review comments through the inline reply API, not a new
+  top-level PR comment.
+- Resolve a review thread only after its valid finding is fixed and pushed, or
+  after an evidence-backed reply shows why no code change is appropriate.
+- A requested review loop never implies merge authority. Stop at a clean,
+  verified PR unless the user explicitly asks to merge.
+- Follow `.codex/skills/review-pr/SKILL.md` for review polling and
+  `.claude/commands/review-pr.md` as the shared command entry point.
+
+## Commits And Releases
+
+- Use Conventional Commits, for example `fix(ci): authenticate pub publishing`.
+- Stage only the files belonging to the current change and inspect the staged
+  diff before committing.
+- Release metadata is owned by `.github/workflows/release.yml`; publishing is
+  owned by `.github/workflows/publish.yml` and pub.dev trusted publishing.
+- A release version change must refresh and commit `example/pubspec.lock`. The
+  ignored root lockfile must not be force-added.
+
+## Workflow Synchronization
+
+- `.codex/skills/` contains the complete, agent-agnostic procedures.
+- `.claude/skills/` contains thin adapters that point to those canonical files.
+- `.claude/commands/` contains concise command entry points and repository check
+  matrices. Do not copy a second independent review or rebase algorithm there.
+- When a canonical skill changes, verify its Claude adapter and command mapping
+  in the same commit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,11 @@
 
 ## [Unreleased]
 
+- Refresh and commit the example lockfile during automated version bumps to prevent recurring release drift ([#409](https://github.com/hyochan/flutter_calendar_carousel/issues/409)).
+- Provision pub.dev OIDC credentials in the publish workflow so tagged releases do not wait for interactive authentication ([#403](https://github.com/hyochan/flutter_calendar_carousel/issues/403)).
+- Update the example to `intl` 0.20.3, current Android build tooling, iOS 13/UIScene, and Flutter Swift Package Manager integration.
+- Add regression coverage for inactive future dates and manual page scrolling, and build the Android example in CI.
+- Synchronize Codex and Claude repository workflows around shared issue, verification, commit, rebase, self-review, and five-minute PR review procedures.
 - Add `upperCaseWeekDays` to render weekday labels in uppercase, including values passed to custom weekday builders ([#392](https://github.com/hyochan/flutter_calendar_carousel/pull/392)).
 - Add `inactiveDates` to render specific dates as non-selectable and ignore taps on those dates ([#395](https://github.com/hyochan/flutter_calendar_carousel/pull/395)).
 - Document the autonomous maintenance runbooks, PR review loop, and deployment workflow expectations ([#402](https://github.com/hyochan/flutter_calendar_carousel/pull/402)).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -9,7 +9,12 @@ android {
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
-    lintOptions {
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    lint {
         disable 'InvalidPackage'
     }
 

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -18,7 +18,8 @@ pluginManagement {
 
 plugins {
     id 'dev.flutter.flutter-plugin-loader' version '1.0.0'
-    id 'com.android.application' version '8.7.0' apply false
+    id 'com.android.application' version '8.13.2' apply false
+    id 'org.jetbrains.kotlin.android' version '2.3.21' apply false
 }
 
 include ':app'

--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -20,7 +20,5 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>MinimumOSVersion</key>
-  <string>12.0</string>
 </dict>
 </plist>

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '12.0'
+# platform :ios, '13.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,22 +1,16 @@
 PODS:
   - Flutter (1.0.0)
-  - integration_test (0.0.1):
-    - Flutter
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
-  - integration_test (from `.symlinks/plugins/integration_test/ios`)
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
-  integration_test:
-    :path: ".symlinks/plugins/integration_test/ios"
 
 SPEC CHECKSUMS:
-  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
 
-PODFILE CHECKSUM: 6e700dec67e6deac9b1c69bb14c49a2217a12d15
+PODFILE CHECKSUM: a3b6f034f0d79a209652621b979bc9d6707da7a1
 
 COCOAPODS: 1.16.2

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		AB01C80AB3C6D4C01BAC11D3 /* libPods-Runner.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CB85E8696418E4D73520843C /* libPods-Runner.a */; };
+		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -67,6 +68,7 @@
 		CAC4DB1D870CD79DB0477C85 /* libPods-RunnerTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RunnerTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB85E8696418E4D73520843C /* libPods-Runner.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Runner.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DF31628B04C46627AB6BC92B /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -82,6 +84,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
 				AB01C80AB3C6D4C01BAC11D3 /* libPods-Runner.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -100,6 +103,7 @@
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
+				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,
 				7AFA3C8E1D35360C0083082E /* Release.xcconfig */,
@@ -199,6 +203,9 @@
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		97C146ED1CF9000F007C117D /* Runner */ = {
+			packageProductDependencies = (
+				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
+			);
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
@@ -223,6 +230,9 @@
 
 /* Begin PBXProject section */
 		97C146E61CF9000F007C117D /* Project object */ = {
+			packageReferences = (
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */,
+			);
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
@@ -448,7 +458,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -566,7 +576,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -617,7 +627,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -696,6 +706,18 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+/* Begin XCLocalSwiftPackageReference section */
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCLocalSwiftPackageReference section */
+/* Begin XCSwiftPackageProductDependency section */
+		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 97C146E61CF9000F007C117D /* Project object */;
 }

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Prepare Flutter Framework Script"
+               scriptText = "/bin/sh &quot;$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh&quot; prepare&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+                     BuildableName = "Runner.app"
+                     BlueprintName = "Runner"
+                     ReferencedContainer = "container:Runner.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -26,6 +44,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -54,6 +73,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/example/ios/Runner/AppDelegate.h
+++ b/example/ios/Runner/AppDelegate.h
@@ -1,6 +1,6 @@
 #import <Flutter/Flutter.h>
 #import <UIKit/UIKit.h>
 
-@interface AppDelegate : FlutterAppDelegate
+@interface AppDelegate : FlutterAppDelegate <FlutterImplicitEngineDelegate>
 
 @end

--- a/example/ios/Runner/AppDelegate.m
+++ b/example/ios/Runner/AppDelegate.m
@@ -5,9 +5,12 @@
 
 - (BOOL)application:(UIApplication *)application
     didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-  [GeneratedPluginRegistrant registerWithRegistry:self];
   // Override point for customization after application launch.
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
+}
+
+- (void)didInitializeImplicitFlutterEngine:(NSObject<FlutterImplicitEngineBridge>*)engineBridge {
+  [GeneratedPluginRegistrant registerWithRegistry:engineBridge.pluginRegistry];
 }
 
 @end

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
@@ -24,6 +26,29 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -41,9 +66,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
 </dict>
 </plist>

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -76,7 +76,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.6.9"
+    version: "2.6.10"
   flutter_driver:
     dependency: transitive
     description: flutter
@@ -109,10 +109,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.20.3"
   leak_tracker:
     dependency: transitive
     description:
@@ -189,10 +189,10 @@ packages:
     dependency: transitive
     description:
       name: process
-      sha256: "107d8be718f120bbba9dcd1e95e3bd325b1b4a4f07db64154635ba03f2567a0d"
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.3"
+    version: "5.0.5"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -202,10 +202,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.2"
   stack_trace:
     dependency: transitive
     description:
@@ -266,18 +266,18 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "15.2.0"
   webdriver:
     dependency: transitive
     description:
       name: webdriver
-      sha256: "3d773670966f02a646319410766d3b5e1037efb7f07cc68f844d5e06cd4d61c8"
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.4"
+    version: "3.1.0"
 sdks:
   dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  intl: ^0.20.2
+  intl: ^0.20.3
 
   flutter_calendar_carousel:
     # When depending on this package from a real application you should use:

--- a/test/flutter_calendar_carousel_test.dart
+++ b/test/flutter_calendar_carousel_test.dart
@@ -107,7 +107,7 @@ void main() {
     DateTime? pressedDay;
     DateTime? longPressedDay;
     final selectedDay = DateTime(2026, 5, 13);
-    final blockedDay = DateTime(2026, 5, 12, 23, 30);
+    final blockedDay = DateTime(2026, 5, 14, 23, 30);
     const inactiveStyle = TextStyle(color: Colors.purple);
 
     final carousel = CalendarCarousel(
@@ -148,6 +148,38 @@ void main() {
     await tester.pump();
 
     expect(longPressedDay, isNull);
+  });
+
+  testWidgets('manual page scroll does not snap at the halfway point', (
+    WidgetTester tester,
+  ) async {
+    final carousel = CalendarCarousel(
+      height: 420,
+      selectedDateTime: DateTime(2026, 5, 13),
+      targetDateTime: DateTime(2026, 5, 13),
+      minSelectedDate: DateTime(2026),
+      maxSelectedDate: DateTime(2026, 12, 31),
+    );
+
+    await tester.pumpWidget(MaterialApp(home: Scaffold(body: carousel)));
+
+    final pageViewFinder = find.byType(PageView);
+    final pageView = tester.widget<PageView>(pageViewFinder);
+    final controller = pageView.controller!;
+    final initialPage = controller.page!;
+    final pageWidth = tester.getSize(pageViewFinder).width;
+
+    final gesture = await tester.startGesture(tester.getCenter(pageViewFinder));
+    await gesture.moveBy(Offset(-pageWidth * 0.1, 0));
+    await tester.pump();
+    await gesture.moveBy(Offset(-pageWidth * 0.55, 0));
+    await tester.pump(const Duration(milliseconds: 2));
+
+    expect(controller.page, greaterThan(initialPage + 0.5));
+    expect(controller.page, lessThan(initialPage + 0.9));
+
+    await gesture.up();
+    await tester.pump();
   });
 
   testWidgets('minSelectedDate compares by calendar day', (


### PR DESCRIPTION
## Summary

- modernize the example for the current Flutter stable toolchain on Android and iOS
- fix release lockfile drift and provision pub.dev trusted-publishing credentials
- expand CI to exercise the example and pin all GitHub Actions to current immutable SHAs
- add regression coverage for inactive future dates and manual page scrolling
- synchronize project-specific Codex and Claude workflows for issues, verification, commits, rebases, self-review, and five-minute PR review loops

## Issue status

- Closes #409. The release job now resolves both root and example dependencies after the version bump and stages only the tracked example lockfile.
- Addresses the repository-side cause in #403 by provisioning the pub.dev OIDC credential before Flutter shadows the setup-dart binary. pub.dev trusted-publishing configuration and a successful future tag publication remain external verification.
- Addresses #404 by requiring routine compatibility checks on the exact current stable SDK; the reported Flutter beta test-loader timeout did not reproduce on stable.
- #407 was already fixed by #408 and confirmed by #412. This PR broadens the filter to all `example/**` and workflow files and adds an Android consumer build.
- Preserves closed fixes from #387 and #396 with focused regression tests.
- Supersedes the conflicting workflow approach in #411 without force-adding the ignored root lockfile.

## Dependencies and compatibility

- Verified against the official Flutter 3.44.9 release hash `6b182d2c7585eba26d4edce0f97630effd256c33` with Dart 3.12.2.
- Root direct and dev dependencies are fully up to date. Remaining newer versions are Flutter-SDK-constrained transitives: `meta`, `vector_math`, `matcher`, and `test_api`.
- Updated example `intl` to 0.20.3, Gradle to 8.14.3, Android Gradle Plugin to 8.13.2, Kotlin to 2.3.21, Java to 17, and iOS to the current Flutter UIScene/SPM migration.
- Updated checkout, setup-java, Codecov, stale, Flutter, and setup-dart actions to their latest stable releases with immutable commit pins.

## Verification

- `dart format --output=none --set-exit-if-changed .`
- `flutter analyze`
- `flutter test --coverage`: 20 passed, 61.94% line coverage
- manual page-scroll regression: 10 consecutive focused passes
- `flutter pub outdated`: direct/dev dependencies all up to date
- `example`: pub get, analyze, and widget test passed
- `flutter build apk --debug` passed
- `flutter build ios --simulator --no-codesign` passed
- clean-HEAD `flutter pub publish --dry-run`: 0 warnings; one existing hint because pub.dev still reports 2.5.4
- all GitHub workflow YAML parsed; iOS plist/scheme validation passed
- all 8 Codex/Claude skill packages passed `quick_validate.py`
- `git diff --check`

## Known external state

pub.dev still reports 2.5.4 while this repository is at 2.6.10. A new tag after this PR merges is required to prove the complete OIDC publishing path. The iOS build succeeds but Flutter still recommends manually removing the example's legacy non-standard CocoaPods integration in favor of a pure SPM setup.
